### PR TITLE
Add ability to make PRs with version change based on release issue

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -7,7 +7,7 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=CVS
+ignore=CVS,tests
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ repository and must be named `CHANGELOG.md`. Changelog for the new version must 
 Everything between this heading and the heading for previous version will be pulled into the changelog.
 
 Alternatively, you can let the bot do the boring work, update `__version__` variable and fill changelog with commit messages from git log. 
-You can trigger this action by creating an issue and name the same as you would a release PR, e.g. `0.1.0 release`. 
+You can trigger this action by creating an issue and name it the same as you would a release PR, e.g. `0.1.0 release`. 
 All you have to do after that is merge the PR that the bot will make.
 
 A `release-conf.yaml` file is required. See [Configuration](#configuration) section for details.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Once the PR is merged, bot will create a new Github release. Changelog will be p
 repository and must be named `CHANGELOG.md`. Changelog for the new version must begin with version heading, i.e `# 0.1.0`.
 Everything between this heading and the heading for previous version will be pulled into the changelog.
 
+Alternatively, you can let the bot do the boring work, update `__version__` variable and fill changelog with commit messages from git log. 
+You can trigger this action by creating an issue and name the same as you would a release PR, e.g. `0.1.0 release`. 
+All you have to do after that is merge the PR that the bot will make.
+
 A `release-conf.yaml` file is required. See [Configuration](#configuration) section for details.
 
 Once a Github release is complete, bot will upload this release to PyPI. Note that you have to setup your login details (see [Requirements](#requirements)).
@@ -27,9 +31,9 @@ Here are the `conf.yaml` configuration options:
 | `repository_name`     | Name of your Github repository  | Yes |
 | `repository_owner`    | Owner of the repository    	  | Yes |
 | `github_token`		| [Github personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)   | Yes |
+| `github_username`	    | Name of the account that the `github_token` belongs to. Only needed for triggering the bot on an issue. | No |
 | `fas_username`		| [FAS](https://fedoraproject.org/wiki/Account_System)	username. Only need for releasing on Fedora| No |
 | `refresh_interval`	| Time in seconds between checks on repository. Default is 180 | No |
-
 Sample config named [conf.yaml](conf.yaml) can be found in this repository.
 
 Regarding `github_token`, it's usually a good idea to create a Github account for the bot (and use its Github API token)
@@ -46,7 +50,7 @@ Here are possible options:
 | `author_email`| Author email for changelog. If not set, author of the merge commit is used	| No |
 | `fedora`      | Whether to release on fedora. False by default | No |
 | `fedora_branches`     | List of branches that you want to release on. Master is always implied | No |
-
+| `trigger_on_issue`| Whether to allow bot to make PRs based on issues. False by default. | No |
 Sample config named [release-conf-example.yaml](release-conf-example.yaml) can be found in this repository.
 
 # Requirements

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -95,39 +95,38 @@ class Configuration:
                 sys.exit(1)
         self.logger.debug(f"Loaded configuration for {self.repository_owner}/{self.repository_name}")
 
-    def load_release_conf(self, conf_dir):
+    def load_release_conf(self, conf):
         """
         Load items from release-conf.yaml
 
-        :param conf_dir: path to directory containing release-conf.yaml
+        :param conf: contents of release-conf.yaml
         :return dict with configuration
         """
-        conf_file_path = Path(conf_dir) / 'release-conf.yaml'
-        if not conf_file_path.is_file():
+        if not conf:
             self.logger.error("No release-conf.yaml found in "
                               f"{self.repository_owner}/{self.repository_name} repository root!\n"
                               "You have to add one for releasing to PyPi/Fedora")
             if self.REQUIRED_ITEMS['release-conf']:
                 sys.exit(1)
 
-        with conf_file_path.open() as conf_file:
-            parsed_conf = yaml.safe_load(conf_file) or {}
-            parsed_conf = {k: v for (k, v) in parsed_conf.items() if v}
-            for item in self.REQUIRED_ITEMS['release-conf']:
-                if item not in parsed_conf:
-                    self.logger.error(f"Item {item!r} is required in release-conf!")
-                    sys.exit(1)
-            for index, version in enumerate(parsed_conf.get('python_versions', [])):
-                parsed_conf['python_versions'][index] = int(version)
-            for index, branch in enumerate(parsed_conf.get('fedora_branches', [])):
-                parsed_conf['fedora_branches'][index] = str(branch)
-            if parsed_conf.get('fedora') and not self.fas_username:
-                self.logger.warning("Can't release to fedora if there is no FAS username, disabling")
-                parsed_conf['fedora'] = False
-            if parsed_conf.get('trigger_on_issue') and not self.github_username:
-                msg = "Can't trigger on issue if 'github_username' is not known, disabling"
-                self.logger.warning(msg)
-                parsed_conf['trigger_on_issue'] = False
+        parsed_conf = yaml.safe_load(conf) or {}
+        parsed_conf = {k: v for (k, v) in parsed_conf.items() if v}
+        for item in self.REQUIRED_ITEMS['release-conf']:
+            if item not in parsed_conf:
+                self.logger.error(f"Item {item!r} is required in release-conf!")
+                sys.exit(1)
+        for index, version in enumerate(parsed_conf.get('python_versions', [])):
+            parsed_conf['python_versions'][index] = int(version)
+        for index, branch in enumerate(parsed_conf.get('fedora_branches', [])):
+            parsed_conf['fedora_branches'][index] = str(branch)
+        if parsed_conf.get('fedora') and not self.fas_username:
+            self.logger.warning("Can't release to fedora if there is no FAS username, disabling")
+            parsed_conf['fedora'] = False
+        if parsed_conf.get('trigger_on_issue') and not self.github_username:
+            msg = "Can't trigger on issue if 'github_username' is not known, disabling"
+            self.logger.warning(msg)
+            parsed_conf['trigger_on_issue'] = False
+
         return parsed_conf
 
 

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -125,7 +125,8 @@ class Configuration:
                 self.logger.warning("Can't release to fedora if there is no FAS username, disabling")
                 parsed_conf['fedora'] = False
             if parsed_conf.get('trigger_on_issue') and not self.github_username:
-                self.logger.warning("Can't trigger on issue if 'github_username' is not known, disabling")
+                msg = "Can't trigger on issue if 'github_username' is not known, disabling"
+                self.logger.warning(msg)
                 parsed_conf['trigger_on_issue'] = False
         return parsed_conf
 

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -32,11 +32,13 @@ class Configuration:
         self.repository_name = ''
         self.repository_owner = ''
         self.github_token = ''
+        self.github_username = ''
         self.refresh_interval = 3 * 60
         self.debug = False
         self.configuration = ''
         self.keytab = ''
         self.fas_username = ''
+        self.version_path = ''
         self.logger = None
         self.set_logging()
 
@@ -122,6 +124,9 @@ class Configuration:
             if parsed_conf.get('fedora') and not self.fas_username:
                 self.logger.warning("Can't release to fedora if there is no FAS username, disabling")
                 parsed_conf['fedora'] = False
+            if parsed_conf.get('trigger_on_issue') and not self.github_username:
+                self.logger.warning("Can't trigger on issue if 'github_username' is not known, disabling")
+                parsed_conf['trigger_on_issue'] = False
         return parsed_conf
 
 

--- a/release_bot/exceptions.py
+++ b/release_bot/exceptions.py
@@ -16,3 +16,7 @@
 
 class ReleaseException(Exception):
     """ Generic exception when something goes wrong. """
+
+
+class GitException(Exception):
+    """ Generic exception when something during git operations fails"""

--- a/release_bot/git.py
+++ b/release_bot/git.py
@@ -1,0 +1,67 @@
+from tempfile import TemporaryDirectory
+from os import path
+
+from release_bot.utils import *
+from release_bot.exceptions import GitException
+
+
+class Git:
+
+    def __init__(self, url, configuration):
+        self.repo = self.clone(url)
+        self.repo_path = self.repo.name
+        self.credential_store = None
+        self.conf = configuration
+        self.logger = configuration.logger
+
+    def clone(self, url):
+        temp_directory = TemporaryDirectory()
+        if not shell_command(temp_directory.name, f'git clone {url} .', "Couldn't clone repository!", fail=False):
+            raise GitException(f"Can't clone repository {url}")
+        return temp_directory
+
+    def get_log_since_last_release(self, latest_version):
+        success, changelog = shell_command_get_output(self.repo_path,
+                                                      f'git log {latest_version}... --no-merges --format=\'* %s\'')
+        return changelog if success and changelog else 'No changelog provided'
+
+    def add(self, files: list):
+        for file in files:
+            success = shell_command(self.repo_path, f'git add {file}', '', False)
+            if not success:
+                raise GitException(f"Can't git add file {file}!")
+
+    def commit(self, message='release commit'):
+        success = shell_command(self.repo_path, f'git commit -m \"{message}\"', '', False)
+        if not success:
+            raise GitException(f"Can't commit files!")
+
+    def push(self, branch):
+        success = shell_command(self.repo_path, f'git push origin {branch}', '', False)
+        if not success:
+            raise GitException(f"Can't push branch {branch} to origin!")
+
+    def set_credentials(self, name, email):
+        email = shell_command(self.repo_path, f'git config user.email "{email}"', '', fail=False)
+        name = shell_command(self.repo_path, f'git config user.name "{name}"', '', fail=False)
+        return email and name
+
+    def set_credential_store(self):
+        if not self.credential_store:
+            self.credential_store = TemporaryDirectory()
+            store_path = path.join(self.credential_store.name, 'credentials')
+            # write down credentials
+            with open(store_path, 'w+') as credentials:
+                credentials.write(
+                    f'https://{self.conf.github_username}:{self.conf.github_token}@github.com/'
+                    f'{self.conf.repository_owner}/{self.conf.repository_name}')
+            # let git know
+            with open(os.path.join(self.repo_path, '.git/config'), 'a+') as config:
+                config.write(f'\n[credential]\n\thelper = store --file={store_path}\n')
+        return path.join(self.credential_store.name, 'credentials')
+
+    def checkout_new_branch(self, branch):
+        return shell_command(self.repo_path, f'git checkout -b "{branch}"', '', fail=False)
+
+    def cleanup(self):
+        self.repo.cleanup()

--- a/release_bot/git.py
+++ b/release_bot/git.py
@@ -1,52 +1,110 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This module provides interface to git
+"""
+
 from tempfile import TemporaryDirectory
 from os import path
 
-from release_bot.utils import *
+from release_bot.utils import shell_command, shell_command_get_output
 from release_bot.exceptions import GitException
 
 
 class Git:
-
-    def __init__(self, url, configuration):
+    """
+    Interface to git
+    """
+    def __init__(self, url, conf):
         self.repo = self.clone(url)
         self.repo_path = self.repo.name
         self.credential_store = None
-        self.conf = configuration
-        self.logger = configuration.logger
+        self.conf = conf
+        self.logger = conf.logger
 
-    def clone(self, url):
+    @staticmethod
+    def clone(url):
+        """
+        Clones repository from url to temporary directory
+        :param url:
+        :return: TemporaryDirectory object
+        """
         temp_directory = TemporaryDirectory()
-        if not shell_command(temp_directory.name, f'git clone {url} .', "Couldn't clone repository!", fail=False):
+        if not shell_command(temp_directory.name, f'git clone {url} .',
+                             "Couldn't clone repository!", fail=False):
             raise GitException(f"Can't clone repository {url}")
         return temp_directory
 
     def get_log_since_last_release(self, latest_version):
-        success, changelog = shell_command_get_output(self.repo_path,
-                                                      f'git log {latest_version}... --no-merges --format=\'* %s\'')
+        """
+        Utilizes git log to get log since last release, excluding merge commits
+        :param latest_version: previous version
+        :return: changelog or placeholder
+        """
+        cmd = f'git log {latest_version}... --no-merges --format=\'* %s\''
+        success, changelog = shell_command_get_output(self.repo_path, cmd)
         return changelog if success and changelog else 'No changelog provided'
 
     def add(self, files: list):
+        """
+        Executes git add
+        :param files: list of files to add
+        :return:
+        """
         for file in files:
             success = shell_command(self.repo_path, f'git add {file}', '', False)
             if not success:
                 raise GitException(f"Can't git add file {file}!")
 
     def commit(self, message='release commit'):
+        """
+        Executes git commit
+        :param message: commit message
+        :return:
+        """
         success = shell_command(self.repo_path, f'git commit -m \"{message}\"', '', False)
         if not success:
             raise GitException(f"Can't commit files!")
 
     def push(self, branch):
+        """
+        Executes git push
+        :param branch: branch to push
+        :return:
+        """
         success = shell_command(self.repo_path, f'git push origin {branch}', '', False)
         if not success:
             raise GitException(f"Can't push branch {branch} to origin!")
 
     def set_credentials(self, name, email):
+        """
+        Sets credentials fo git repo to keep git from resisting to commit
+        :param name: committer name
+        :param email: committer email
+        :return: True on success False on fail
+        """
         email = shell_command(self.repo_path, f'git config user.email "{email}"', '', fail=False)
         name = shell_command(self.repo_path, f'git config user.name "{name}"', '', fail=False)
         return email and name
 
     def set_credential_store(self):
+        """
+        Edits local git config with credentials to be used for pushing
+        :return: path to temp file with credentials
+        """
         if not self.credential_store:
             self.credential_store = TemporaryDirectory()
             store_path = path.join(self.credential_store.name, 'credentials')
@@ -56,12 +114,21 @@ class Git:
                     f'https://{self.conf.github_username}:{self.conf.github_token}@github.com/'
                     f'{self.conf.repository_owner}/{self.conf.repository_name}')
             # let git know
-            with open(os.path.join(self.repo_path, '.git/config'), 'a+') as config:
+            with open(path.join(self.repo_path, '.git/config'), 'a+') as config:
                 config.write(f'\n[credential]\n\thelper = store --file={store_path}\n')
         return path.join(self.credential_store.name, 'credentials')
 
     def checkout_new_branch(self, branch):
+        """
+        Creates a new local branch
+        :param branch: branch name
+        :return: True on success False on fail
+        """
         return shell_command(self.repo_path, f'git checkout -b "{branch}"', '', fail=False)
 
     def cleanup(self):
+        """
+        Cleans up the directory with repository
+        :return:
+        """
         self.repo.cleanup()

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -17,13 +17,13 @@ from os import listdir
 import requests
 from tempfile import TemporaryDirectory
 from zipfile import ZipFile
+from release_bot.git import Git
 
-from release_bot.exceptions import ReleaseException
-from release_bot.utils import parse_changelog
+from release_bot.exceptions import ReleaseException, GitException
+from release_bot.utils import *
 
 
 class Github:
-
     API_ENDPOINT = "https://api.github.com/graphql"
     API3_ENDPOINT = "https://api.github.com/"
 
@@ -101,7 +101,7 @@ class Github:
 
         return release['name']
 
-    def walk_through_closed_prs(self, start='', direction='after', which="last"):
+    def walk_through_prs(self, start='', direction='after', which="last", closed=True):
         """
         Searches merged pull requests
 
@@ -111,8 +111,9 @@ class Github:
                       should be returned, can be 'first' or 'last'
         :return: edges from API query response
         """
+        state = 'MERGED' if closed else 'OPEN'
         while True:
-            query = (f"pullRequests(states: MERGED {which}: 5 " +
+            query = (f"pullRequests(states: {state} {which}: 5 " +
                      (f'{direction}: "{start}"' if start else '') +
                      '''){
                   edges {
@@ -133,6 +134,30 @@ class Github:
             response = self.query_repository(query).json()
             self.detect_api_errors(response)
             return response['data']['repository']['pullRequests']['edges']
+
+    def walk_through_open_issues(self, start='', direction='after', which="last"):
+        """
+        Searches open issues for a release trigger
+
+        :return: edges from API query response
+        """
+        while True:
+            query = (f"issues(states: OPEN {which}: 5 " +
+                     (f'{direction}: "{start}"' if start else '') +
+                     '''){
+                  edges {
+                    cursor
+                    node {
+                      id
+                      number
+                      title
+                      authorAssociation
+                    }
+                  }
+                }''')
+            response = self.query_repository(query).json()
+            self.detect_api_errors(response)
+            return response['data']['repository']['issues']['edges']
 
     def make_new_release(self, new_release, previous_pypi_release):
         """
@@ -199,3 +224,121 @@ class Github:
         if response.status_code != 200:
             self.logger.error((f"Something went wrong during changelog "
                                f"update for {new_version}:\n{response.text}"))
+
+    def clone_repository(self):
+        url = f'https://github.com/{self.conf.repository_owner}/{self.conf.repository_name}.git'
+        return Git(url, self.conf)
+
+    def check_branch_existence(self, branch):
+        url = (f"{self.API3_ENDPOINT}repos/{self.conf.repository_owner}/"
+               f"{self.conf.repository_name}/branches/{branch}")
+        response = requests.post(url=url, headers=self.headers)
+        if response.status_code == 200:
+            return True
+        elif response.status_code == 404:
+            return False
+        else:
+            msg = f"Unexpected response code from Github:\n{response.text}"
+            raise ReleaseException(msg)
+
+    def make_pr(self, branch, version, log, changed_version_files, base='master'):
+        message = (f'Hi,\n you have requested a release PR from me. Here it is!\nThis is the changelog I created:\n'
+                   f'### Changes\n{log}\n\nYou can change it by editing `CHANGELOG.md` '
+                   f'in the root of this repository and pushing to `{branch}` branch before merging this PR.\n')
+        if len(changed_version_files) == 1:
+            message += 'I have also updated the  `__version__ ` in file:\n'
+        elif len(changed_version_files) > 1:
+            message += ('There were multiple files where  `__version__ ` was set, so I left updating them up to you.'
+                        'These are the files:\n')
+        elif len(changed_version_files) == 0:
+            message += "I didn't find any files where  `__version__` is set."
+
+        for file in changed_version_files:
+            message += f'* {file}\n'
+
+        payload = {'title': f'{version} release',
+                   'head': branch,
+                   'base': base,
+                   'body': message,
+                   'maintainer_can_modify': True}
+        url = (f"{self.API3_ENDPOINT}repos/{self.conf.repository_owner}/"
+               f"{self.conf.repository_name}/pulls")
+        self.logger.debug(f'Attempting a PR for {branch} branch')
+        response = requests.post(url=url, headers=self.headers, json=payload)
+        if response.status_code == 201:
+            parsed = response.json()
+            self.logger.info(f"Created PR: {parsed['html_url']}")
+            return parsed['html_url']
+        else:
+            msg = (f"Something went wrong with creating "
+                   f"PR on github:\n{response.text}")
+            raise ReleaseException(msg)
+
+    def make_release_pr(self, new_pr):
+        repo = new_pr['repo']
+        version = new_pr['version']
+        branch = f'{version}-release'
+        if not self.check_branch_existence(branch):
+            try:
+                name, email = self.get_user_contact()
+                repo.set_credentials(name, email)
+                repo.set_credential_store()
+                changelog = repo.get_log_since_last_release(new_pr['previous_version'])
+                repo.checkout_new_branch(branch)
+                insert_in_changelog(f'{repo.repo_path}/CHANGELOG.md', new_pr['version'], changelog)
+                changed = look_for_version_files(repo.repo_path, new_pr['version'])
+                repo.add(['.'])
+                repo.commit(f'{version} release')
+                repo.push(branch)
+                if not self.check_if_pr_exists(f'{version} release'):
+                    new_pr['pr_url'] = self.make_pr(branch, f'{version}', changelog, changed)
+                    return True
+            except GitException as exc:
+                raise ReleaseException(exc)
+        else:
+            self.logger.warning(f'Branch {branch} already exists, aborting creating PR.')
+        return False
+
+    def check_if_pr_exists(self, name):
+        cursor = ''
+        while True:
+            edges = self.walk_through_prs(start=cursor, direction='before', closed=False)
+            if not edges:
+                self.logger.debug(f"No open PR's found")
+                return False
+
+            for edge in reversed(edges):
+                cursor = edge['cursor']
+                match = re.match(name, edge['node']['title'].lower())
+                if match:
+                    return True
+
+    def get_user_contact(self):
+        query = (f'query {{user(login: "{self.conf.github_username}")'
+                 '''  {
+                     email
+                     name
+                   }
+                 }''')
+        response = self.send_query(query).json()
+        self.detect_api_errors(response)
+        name = response['data']['user']['name']
+        email = response['data']['user']['email']
+        if not name:
+            name = 'Release bot'
+        if not email:
+            email = 'bot@releasebot.bot'
+        return name, email
+
+    def close_issue(self, number):
+        payload = {'state': 'closed'}
+        url = (f"{self.API3_ENDPOINT}repos/{self.conf.repository_owner}/"
+               f"{self.conf.repository_name}/issues/{number}")
+        self.logger.debug(f'Attempting to close issue #{number}')
+        response = requests.patch(url=url, headers=self.headers, json=payload)
+        if response.status_code == 200:
+            self.logger.debug(f'Closed issue #{number}')
+            return True
+        else:
+            self.logger.error(f'Failed to close issue #{number}')
+            return False

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -51,11 +51,14 @@ class ReleaseBot:
         self.fedora.progress_log = []
 
     def load_release_conf(self):
+        """
+        Updates new_release with latest release-conf.yaml from repository
+        :return:
+        """
         # load release configuration from release-conf.yaml in repository
-        repo = self.github.clone_repository()
-        release_conf = self.conf.load_release_conf(repo.repo_path)
+        conf = self.github.get_configuration()
+        release_conf = self.conf.load_release_conf(conf)
         self.new_release.update(release_conf)
-        repo.cleanup()
 
     def find_open_release_issues(self):
         """
@@ -234,8 +237,8 @@ class ReleaseBot:
         while True:
             try:
                 if self.find_newest_release_pull_request():
-                    self.make_new_github_release()
                     self.load_release_conf()
+                    self.make_new_github_release()
                     # Try to do PyPi release regardless whether we just did github release
                     # for case that in previous iteration (of the 'while True' loop)
                     # we succeeded with github release, but failed with PyPi release

--- a/release_bot/utils.py
+++ b/release_bot/utils.py
@@ -19,7 +19,7 @@ import os
 import re
 import subprocess
 import locale
-from semantic_version import Version
+from semantic_version import Version, validate
 
 from release_bot.configuration import configuration
 from release_bot.exceptions import ReleaseException
@@ -100,6 +100,7 @@ def shell_command(work_directory, cmd, error_message, fail=True):
         shell=False,
         cwd=work_directory,
         universal_newlines=True)
+
     configuration.logger.debug(f"{shell.args}\n{shell.stdout}")
     if shell.returncode != 0:
         configuration.logger.error(f"{error_message}\n{shell.stderr}")
@@ -107,3 +108,72 @@ def shell_command(work_directory, cmd, error_message, fail=True):
             raise ReleaseException(f"{shell.args!r} failed with {error_message!r}")
         return False
     return True
+
+
+def shell_command_get_output(work_directory, cmd):
+    cmd = shlex.split(cmd)
+    shell = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        shell=False,
+        cwd=work_directory,
+        universal_newlines=True)
+    success = shell.returncode == 0
+    if not success:
+        return success, shell.stderr
+    return success, shell.stdout
+
+
+def insert_in_changelog(changelog, version, log):
+    content = f"# {version}\n\n{log}\n"
+    try:
+        with open(changelog, 'r+') as file:
+            original = file.read()
+            file.seek(0)
+            file.write(content + original)
+    except FileNotFoundError as exc:
+        configuration.logger.warning(f"No CHANGELOG.md present in repository\n{exc}")
+
+
+def look_for_version_files(repo_directory, new_version):
+    changed = []
+    for root, dirs, files in os.walk(repo_directory):
+        for file in files:
+            if file in ('setup.py', '__init__.py', 'version.py'):
+                filename = os.path.join(root, file)
+                success = update_version(filename, new_version)
+                if success:
+                    changed.append(filename.replace(repo_directory + '/', '', 1))
+    if len(changed) > 1:
+        configuration.logger.error('Multiple version files found. Aborting version update.')
+    elif len(changed) == 0:
+        configuration.logger.error('No version files found. Aborting version update.')
+
+    return changed
+
+
+def update_version(file, new_version):
+    with open(file, 'r') as fd:
+        content = fd.read().splitlines()
+
+    changed = False
+    for index, line in enumerate(content):
+        if line.startswith('__version__'):
+            pieces = line.split('=', maxsplit=1)
+            if len(pieces) == 2:
+                configuration.logger.info(f"Editing line with new version:\n{line}")
+                old_version = (pieces[1].strip())[1:-1]  # strip whitespace and ' or "
+                if validate(old_version):
+                    configuration.logger.info(f"Replacing version {old_version} with {new_version} ...")
+                    content[index] = f"{pieces[0].strip()} = '{new_version}'"
+                    changed = True
+                    break
+                else:
+                    configuration.logger.warning(f"Failed to validate version, aborting")
+                    return False
+    if changed:
+        with open(file, 'w') as fd:
+            fd.write('\n'.join(content) + '\n')
+        configuration.logger.info('Version replaced.')
+    return changed

--- a/tests/test_load_release_conf.py
+++ b/tests/test_load_release_conf.py
@@ -13,14 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from release_bot.configuration import configuration
 from pathlib import Path
 import pytest
+
+from release_bot.configuration import configuration
 
 
 class TestLoadReleaseConf:
 
-    def setup_method(self, method):
+    def setup_method(self):
         """ setup any state tied to the execution of the given method in a
         class.  setup_method is invoked for every test method of a class.
         """
@@ -33,17 +34,27 @@ class TestLoadReleaseConf:
         """
 
     @pytest.fixture
-    def empty_conf(self, tmpdir):
-        conf = Path(str(tmpdir))/"relase-conf.yaml"
-        conf.touch()
-        return str(tmpdir)
+    def empty_conf(self):
+        """
+        Emulates an empty configuration
+        :return:
+        """
+        return ""
 
     @pytest.fixture
-    def non_existing_conf(self, tmpdir):
-        return str(tmpdir)
+    def non_existing_conf(self):
+        """
+        Emulates missing configuration
+        :return:
+        """
+        return False
 
     @pytest.fixture
     def valid_new_release(self):
+        """
+        Emulates valid new_release dict
+        :return:
+        """
         new_release = {'version': '0.1.0',
                        'commitish': 'xxx',
                        'author_name': 'John Doe',
@@ -57,25 +68,28 @@ class TestLoadReleaseConf:
         return new_release
 
     @pytest.fixture
-    def missing_items_conf(self, tmpdir):
-        conf_content = (Path(__file__).parent/"src/missing_items_conf.yaml").read_text()
-        conf = Path(str(tmpdir))/"release-conf.yaml"
-        conf.write_text(conf_content)
-        return str(tmpdir)
+    def missing_items_conf(self):
+        """
+        Emulates configuration with missing required items
+        :return:
+        """
+        return (Path(__file__).parent / "src/missing_items_conf.yaml").read_text()
 
     @pytest.fixture
-    def missing_author_conf(self, tmpdir):
-        conf_content = (Path(__file__).parent/"src/missing_author.yaml").read_text()
-        conf = Path(str(tmpdir))/"release-conf.yaml"
-        conf.write_text(conf_content)
-        return str(tmpdir)
+    def missing_author_conf(self):
+        """
+        Emulates configuration with missing author
+        :return:
+        """
+        return (Path(__file__).parent / "src/missing_author.yaml").read_text()
 
     @pytest.fixture
-    def valid_conf(self, tmpdir):
-        conf_content = (Path(__file__).parent/"src/release-conf.yaml").read_text()
-        conf = Path(str(tmpdir))/"release-conf.yaml"
-        conf.write_text(conf_content)
-        return str(tmpdir)
+    def valid_conf(self):
+        """
+        Emulates valid configuration
+        :return:
+        """
+        return (Path(__file__).parent / "src/release-conf.yaml").read_text()
 
     def test_empty_conf(self, empty_conf):
         # if there are any required items, this test must fail


### PR DESCRIPTION
This PR adds the ability for bot to be triggered by github issue with name like 'x.x.x release'. If this issue is made by someone who has commit access to repository, bot does the following:

- checks if  new version > current version
- clones the repo
- creates a new branch named x.x.x-release
- edits CHANGELOG.md with log from parsed `git log` excluding merges
  - The expected workflow is that this will provide maintainer with something to base their changelog on
- Tries to find `__version__` variable in files like `__init__.py`, `setup.py`,` version.py` and update it to the new version number
- Pushes it's changes and makes a PR from the new branch with changes summed up
- if PR is made, closes the original issue and comments a link to the PR

If this PR is merged (further edits are possible by pushing to the branch), the rest of release-bot takes over and performs a release like it would normally.

This PR also includes a change in loading `release-conf.yaml`, before it was from previous release, I've changed it to load from freshly cloned repo. I believe this is for the better, because as it worked before, changes in configuration for the bot for the current release would already had to be in previous release. Correct me if I'm wrong, please.

I had requested review from @jpopelka as he is maintaining this bot, but I'll be glad for any review to improve my code.  

This would close #74 