### PR TITLE
Bugfixes

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -21,7 +21,4 @@ RUN chown -R 1001:0 ${HOME}
 
 USER 1001
 
-RUN git config --global user.email "jdoe@example.com" && \
-    git config --global user.name "John Doe"
-
 CMD make test

--- a/release_bot/fedora.py
+++ b/release_bot/fedora.py
@@ -39,6 +39,19 @@ class Fedora:
             return ''
 
     @staticmethod
+    def set_git_credentials(repo_path, name, email):
+        """
+        Sets credentials fo git repo to keep git from resisting to commit
+        :param repo_path: path to git repository
+        :param name: committer name
+        :param email: committer email
+        :return: True on success False on fail
+        """
+        email = shell_command(repo_path, f'git config user.email "{email}"', '', fail=False)
+        name = shell_command(repo_path, f'git config user.name "{name}"', '', fail=False)
+        return email and name
+
+    @staticmethod
     def fedpkg_switch_branch(directory, branch, fail=True):
         if not os.path.isdir(directory):
             raise ReleaseException("Cannot access fedpkg repository:")
@@ -201,6 +214,12 @@ class Fedora:
         # clone the repository from dist-git
         fedpkg_root = self.fedpkg_clone_repository(tmp.name, self.conf.repository_name)
         if not fedpkg_root:
+            return False
+
+        # set git credentials
+        if not self.set_git_credentials(fedpkg_root,
+                                        new_release['commit_name'],
+                                        new_release['commit_email']):
             return False
 
         # make sure the current branch is master

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -324,10 +324,9 @@ class Github:
             changelog = repo.get_log_since_last_release(new_pr['previous_version'])
             repo.checkout_new_branch(branch)
             changed = look_for_version_files(repo.repo_path, new_pr['version'])
-            changelog_changed = insert_in_changelog(f'{repo.repo_path}/CHANGELOG.md',
-                                                    new_pr['version'], changelog)
-            if changelog_changed:
-                changed.append(f'{repo.repo_path}/CHANGELOG.md')
+            if insert_in_changelog(f'{repo.repo_path}/CHANGELOG.md',
+                                   new_pr['version'], changelog):
+                repo.add(['CHANGELOG.md'])
             if changed:
                 repo.add(changed)
             repo.commit(f'{version} release', allow_empty=True)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -234,6 +234,9 @@ class ReleaseBot:
             self.github.comment.append(msg)
 
         try:
+            name, email = self.github.get_user_contact()
+            self.new_release['commit_name'] = name
+            self.new_release['commit_email'] = email
             success_ = self.fedora.release(self.new_release)
             release_handler(success_)
         except ReleaseException:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -72,16 +72,19 @@ class TestBot:
         self.g_utils.open_issue("0.0.1 release")
         self.g_utils.open_issue("0.0.2 release")
 
-    @pytest.fixture()
     def open_pr(self):
         """Opens two release issues in a repository"""
         conf = yaml.safe_load(RELEASE_CONF) or {}
         self.release_bot.new_release.update(conf)
-        self.open_issue()
+        self.g_utils.open_issue("0.0.1 release")
         self.release_bot.find_open_release_issues()
         self.release_bot.make_release_pull_request()
         pr_number = self.release_bot.github.pr_exists("0.0.1 release")
         assert pr_number and self.g_utils.merge_pull_request(pr_number)
+
+    @pytest.fixture()
+    def open_pr_fixture(self):
+        self.open_pr()
 
     @pytest.fixture()
     def github_release(self):
@@ -124,7 +127,7 @@ class TestBot:
         assert self.release_bot.make_release_pull_request()
         assert self.release_bot.github.pr_exists("0.0.1 release")
 
-    def test_github_release(self, open_pr):
+    def test_github_release(self, open_pr_fixture):
         """Tests releasing on Github"""
         assert self.release_bot.find_newest_release_pull_request()
         self.release_bot.make_new_github_release()

--- a/tests/test_fedora.py
+++ b/tests/test_fedora.py
@@ -73,6 +73,7 @@ class TestFedora:
     def create_fake_repository(self, directory, non_ff=False):
         self.run_cmd("git init .", directory)
         self.run_cmd("git checkout -b master", directory)
+        assert self.fedora.set_git_credentials(directory, "Name", "email@email.com")
         spec_content = Path(__file__).parent.joinpath("src/example.spec").read_text()
         Path(directory).joinpath("example.spec").write_text(spec_content)
         self.run_cmd("git add .", directory)
@@ -93,6 +94,8 @@ class TestFedora:
                        'commitish': '',
                        'author_name': 'John Doe',
                        'author_email': 'jdoe@example.com',
+                       'commit_name': 'Testy McTestFace',
+                       'commit_email': 'email@email.com',
                        'python_versions': [3],
                        'fedora_branches': ["f28"],
                        'fedora': True,
@@ -163,7 +166,7 @@ class TestFedora:
 
     @pytest.fixture
     def non_existent_path(self, tmpdir):
-        path = Path(str(tmpdir))/'fooo'
+        path = Path(str(tmpdir)) / 'fooo'
         return str(path)
 
     @pytest.fixture
@@ -177,8 +180,8 @@ class TestFedora:
 
     @pytest.fixture
     def example_spec(self, tmpdir):
-        spec_content = (Path(__file__).parent/"src/example.spec").read_text()
-        spec = Path(str(tmpdir))/"example.spec"
+        spec_content = (Path(__file__).parent / "src/example.spec").read_text()
+        spec = Path(str(tmpdir)) / "example.spec"
         spec.write_text(spec_content)
         return str(spec)
 
@@ -220,8 +223,8 @@ class TestFedora:
 
     def test_clone(self, tmp, package, fake_clone):
         directory = Path(self.fedora.fedpkg_clone_repository(tmp, package))
-        assert (directory/f"{package}.spec").is_file()
-        assert (directory/".git").is_dir()
+        assert (directory / f"{package}.spec").is_file()
+        assert (directory / ".git").is_dir()
 
     def test_switch_branch(self, fake_repository):
         self.fedora.fedpkg_switch_branch(fake_repository, "f28", False)
@@ -230,7 +233,7 @@ class TestFedora:
         assert "master" == self.run_cmd("git rev-parse --abbrev-ref HEAD", fake_repository).stdout.strip()
 
     def test_commit(self, fake_repository):
-        spec_path = fake_repository/"example.spec"
+        spec_path = fake_repository / "example.spec"
         spec_content = spec_path.read_text() + "\n Test test"
         spec_path.write_text(spec_content)
 
@@ -244,7 +247,7 @@ class TestFedora:
         directory = Path(self.fedora.fedpkg_clone_repository(tmp, package))
         assert self.fedora.fedpkg_lint(str(directory), "master", False)
 
-        spec_path = directory/f"{package}.spec"
+        spec_path = directory / f"{package}.spec"
         with spec_path.open('r+') as spec_file:
             spec = spec_file.read() + "\n Test test"
             spec_file.write(spec)
@@ -263,7 +266,7 @@ class TestFedora:
         assert file_number != len(os.listdir(directory))
 
     def test_workflow(self, fake_repository):
-        spec_path = fake_repository/"example.spec"
+        spec_path = fake_repository / "example.spec"
         spec_content = spec_path.read_text() + "\n Test test"
         spec_path.write_text(spec_content)
 


### PR DESCRIPTION
This PR contains few quick fixes:

- Fedora releasing failing on no git credentials (fix #84)
- Wrong PR description concerning version bump (fix #83)
- Avoiding direct fixture calling by changing functions in question to regular class functions and creating fixture wrappers to surpass pytest complaining  