### PR TITLE
remove check for github_api_status

### DIFF
--- a/tests/github_utils.py
+++ b/tests/github_utils.py
@@ -143,16 +143,3 @@ class GithubUtils:
                             f'{response.text}')
         parsed = response.json()
         return len(parsed)
-
-    @staticmethod
-    def github_api_status():
-        """Checks status of Github API"""
-        url = f"https://status.github.com/api/status.json"
-        response = requests.get(url=url)
-
-        if response.status_code != 200:
-            return False
-        parsed = response.json()
-        if parsed['status'] != 'good':
-            return False
-        return True

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -24,7 +24,6 @@ from tests.conftest import prepare_conf
 from .github_utils import GithubUtils, RELEASE_CONF
 
 
-@pytest.mark.skipif(not GithubUtils.github_api_status(), reason="Github api is down")
 @pytest.mark.skipif(not os.environ.get('GITHUB_TOKEN'),
                     reason="missing GITHUB_TOKEN environment variable")
 class TestBot:

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -22,7 +22,6 @@ from tests.conftest import prepare_conf
 from .github_utils import GithubUtils, RELEASE_CONF
 
 
-@pytest.mark.skipif(not GithubUtils.github_api_status(), reason="Github api is down")
 @pytest.mark.skipif(not os.environ.get('GITHUB_TOKEN'),
                     reason="missing GITHUB_TOKEN environment variable")
 class TestGithub:


### PR DESCRIPTION
If the API is down, let's just fail the tests and wait for it to be up again.

Also, the status.github.com does not work any more.