### PR TITLE
Make function checkout back to master

### DIFF
--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -429,6 +429,7 @@ class Github:
             name, email = self.get_user_contact()
             repo.set_credentials(name, email)
             repo.set_credential_store()
+            repo.checkout('master')
             changelog = repo.get_log_since_last_release(new_pr['previous_version'])
             repo.checkout_new_branch(branch)
             changed = look_for_version_files(repo.repo_path, new_pr['version'])
@@ -445,6 +446,8 @@ class Github:
                 return True
         except GitException as exc:
             raise ReleaseException(exc)
+        finally:
+            repo.checkout('master')
         return False
 
     def pr_exists(self, name):

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -432,7 +432,7 @@ class Github:
             # The bot first checks out the master branch and from master
             # it creates the new branch, checks out to it and then perform the release
             # This makes sure that the new release_pr branch has all the commits
-            # from the master branch for the lastest release.    
+            # from the master branch for the lastest release.
             repo.checkout('master')
             changelog = repo.get_log_since_last_release(new_pr['previous_version'])
             repo.checkout_new_branch(branch)

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -429,6 +429,10 @@ class Github:
             name, email = self.get_user_contact()
             repo.set_credentials(name, email)
             repo.set_credential_store()
+            # The bot first checks out the master branch and from master
+            # it creates the new branch, checks out to it and then perform the release
+            # This makes sure that the new release_pr branch has all the commits
+            # from the master branch for the lastest release.    
             repo.checkout('master')
             changelog = repo.get_log_since_last_release(new_pr['previous_version'])
             repo.checkout_new_branch(branch)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -234,6 +234,8 @@ class ReleaseBot:
         except ReleaseException:
             release_handler(success=False)
             raise
+        finally:
+            self.git.checkout('master')
 
         return True
 


### PR DESCRIPTION
This solves the bug #173 
* make_new_pypi_release() will now check back to master hence will have no side effect to other functions.

* make_release_pr() will additionally checkout for master again because its important that the current branch is master before release pr branching

* make_release_pr() will also check back to master after doing the release_pr 