### PR TITLE
GitReleaseLog

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Once a Github release is complete, bot will upload this release to PyPI.
 Note that you have to setup your login details (see [Requirements](#requirements)).
 
 ## Try it locally
+
+### Install
 ```
 $ pip install release-bot
 ```
@@ -43,7 +45,25 @@ Other possible installations are through
 
 First interaction with release bot may be automated releases on Github. Let's do it.
 
-#### 1. Create upstream repository or use existing one
+### Configure the release bot
+Release bot can be configured in two ways, using `release-bot init` or manually
+
+#### Configuration using `release-bot init`
+Clone the upstream repository where new releases will be published
+and from the root dir of the repository run the following command:
+```shell
+release-bot init
+```
+Enter the required details when asked by the bot. All of the default choices provided by the init should be enough for the current trial. You will also need to generate a [Github personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
+Recommended permissions for access token are: `repo`, `delete_repo`, `user`.
+
+You can later on modify all the config files. For possible advanced setup check [the documentation for an upstream repository](#upstream-repository) and [gitchanelog](#GitChangeLog).
+
+After the init is completed **commit all of the changes and push it** to the upstream repo.
+
+#### Manual Configuration
+
+##### 1. Create upstream repository or use existing one
 This is meant to be upstream repository where new releases will be published.
 
 Within upstream repository create `release-conf.yaml` file which contains info on how to release the specific project.
@@ -54,9 +74,11 @@ At the end of `release-conf.yaml` add this line of code:
 # whether to allow bot to make PRs based on issues
 trigger_on_issue: true
 ```
-For possible advanced setup check [the documentation for an upstream repository](#upstream-repository).
+Then copy [.gitchangelog.rc](/gitchangelog/.gitchangelog.rc) and [markdown.tpl](/gitchangelog/.gitchangelog.rc) (which are the config files for the [gitchangelog](https://github.com/vaab/gitchangelog.git))
+to the root dir of the upstream repository.
+For possible advanced setup check [the documentation for an upstream repository](#upstream-repository) and [gitchanelog](#GitChangeLog).
 
-#### 2. Create `conf.yaml`
+##### 2. Create `conf.yaml`
 
 Create configuration file `conf.yaml`. You can use [one](conf.yaml) from this repository. You will need to generate a [Github personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/).
 Recommended permissions for access token are: `repo`, `delete_repo`, `user`.
@@ -66,20 +88,21 @@ At the end of `conf.yaml` add this line of code:
 # Name of the account that the github_token belongs to
 # Only needed for triggering the bot on an issue.
 github_username: <your_github_username>
+gitchangelog: true
 ```
 **Note**: This file **should not** be stored in upstream repository as it contains sensitive data.
 
 For possible advanced setup check [the documentation for a private repository](#private-repository).
 Also, see [requirements](#requirements) in case you want include PyPi releases.
 
-#### 3. Run release-bot
-At this point, release-bot is installed. At least two configuration files are set `release-conf.yaml` and `conf.yaml` (optionally `.pypirc`).
+### Run the release-bot
+At this point, release-bot is installed. At least four configuration files are set `release-conf.yaml`, `conf.yaml`, `.gitchangelog.rc`, `markdown.tpl` (optionally `.pypirc`).
 
  Launch bot by a command:
 ```$ release-bot -c <path_to_conf.yaml> --debug```
 You can scroll down and see debug information of running bot.
 
-#### 4. Make a new release
+### Make a new release
 - Create an issue having `0.0.1 release` as a title in your upstream repository. You can select your own version numbers.
 - Wait for the bot to make a new PR based on this issue (refresh interval is set in `conf.yaml`).
 - Once the PR is merged bot will make a new release.
@@ -94,6 +117,9 @@ There are two yaml configuration files:
  1. `conf.yaml` -- a config for the bot itself with some sensitive data (recommended to store in private repo)
  2. `release-conf.yaml` -- stored in upstream repository and contains info on how to release the specific project.
 
+There are two more files required if you use `gitchangelog` to genereate change logs:
+ 1. `.gitchangelog.rc` -- a config file used by the gitchangelog to specify the regex for converting commits and the output engine
+ 2.  `markdown.tpl` -- a template file used by pystache to genereate markdown
 
 ## Private repository
 You need to setup a git repository, where you'll store  the `conf.yaml` and `.pypirc` files.
@@ -114,6 +140,7 @@ Here are the `conf.yaml` configuration options:
 | `github_app_cert_path`       | Path to a certificate which Github provides as an auth mechanism for Github apps. | No |
 | `refresh_interval`           | Time in seconds between checks on repository. Default is 180 | No |
 | `clone_url`                  | URL used to clone your Github repository. By default, `https` variant is used. | No |
+| `use_gitchangelog`           | Whether to use gitchanelog to generate change logs. False by default | No |
 
 Sample config named [conf.yaml](conf.yaml) can be found in this repository.
 
@@ -144,6 +171,13 @@ Here are possible options:
 | `labels`      | List of labels that bot will put on issues and PRs | No |
 
 Sample config named [release-conf-example.yaml](release-conf-example.yaml) can be found in this repository.
+
+## GitChangeLog
+
+For using the [gitchangelog](https://github.com/vaab/gitchangelog) you must add the line `gitchanelog: true` to the conf.yaml, and add the files `.gitchangelog.rc` and `markdown.tpl` in the root of your upstream project repository. Sample config files: [.gitchangelog.rc](/gitchangelog/.gitchangelog.rc) and [template.tpl](/gitchangelog/template.tpl).
+
+`.gitchangelog.rc` sample is heavily commented and should be enough to make modification but for specific details you can refer to the original [repository](https://github.com/vaab/gitchangelog).
+The default template `markdown.tpl` is configured to create Markdown divided into sections (New, Changes, Fix, Others) based on the commits. The data sent to the output engine [pystache](https://github.com/defunkt/pystache) by the gitchangelog is in the following [format](https://github.com/vaab/gitchangelog/edit/master/README.rst#L331-L356). You can use it to create a custom template, please refer [mustache](http://mustache.github.io/).
 
 ## Requirements
 Are specified in `requirements.txt`.
@@ -214,7 +248,7 @@ $ aurman -S release-bot
 You can also install it by using the [PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=release-bot) from the AUR repository.
 To build the package, download the PKGBUILD and exectute:
 ```
-$ makepkg -cs #c flag cleans the extra remaining source and compiled files. s flag installs the dependencies if you don't have it. 
+$ makepkg -cs #c flag cleans the extra remaining source and compiled files. s flag installs the dependencies if you don't have it.
 ```
 To install the package execute,
 ```

--- a/gitchangelog/.gitchangelog.rc
+++ b/gitchangelog/.gitchangelog.rc
@@ -1,0 +1,289 @@
+# -*- coding: utf-8; mode: python -*-
+##
+## Format
+##
+##   ACTION: [AUDIENCE:] COMMIT_MSG [!TAG ...]
+##
+## Description
+##
+##   ACTION is one of 'chg', 'fix', 'new'
+##
+##       Is WHAT the change is about.
+##
+##       'chg' is for refactor, small improvement, cosmetic changes...
+##       'fix' is for bug fixes
+##       'new' is for new features, big improvement
+##
+##   AUDIENCE is optional and one of 'dev', 'usr', 'pkg', 'test', 'doc'
+##
+##       Is WHO is concerned by the change.
+##
+##       'dev'  is for developpers (API changes, refactors...)
+##       'usr'  is for final users (UI changes)
+##       'pkg'  is for packagers   (packaging changes)
+##       'test' is for testers     (test only related changes)
+##       'doc'  is for doc guys    (doc only changes)
+##
+##   COMMIT_MSG is ... well ... the commit message itself.
+##
+##   TAGs are additionnal adjective as 'refactor' 'minor' 'cosmetic'
+##
+##       They are preceded with a '!' or a '@' (prefer the former, as the
+##       latter is wrongly interpreted in github.) Commonly used tags are:
+##
+##       'refactor' is obviously for refactoring code only
+##       'minor' is for a very meaningless change (a typo, adding a comment)
+##       'cosmetic' is for cosmetic driven change (re-indentation, 80-col...)
+##       'wip' is for partial functionality but complete subfunctionality.
+##
+## Example:
+##
+##   new: usr: support of bazaar implemented
+##   chg: re-indentend some lines !cosmetic
+##   new: dev: updated code to be compatible with last version of killer lib.
+##   fix: pkg: updated year of licence coverage.
+##   new: test: added a bunch of test around user usability of feature X.
+##   fix: typo in spelling my name in comment. !minor
+##
+##   Please note that multi-line commit message are supported, and only the
+##   first line will be considered as the "summary" of the commit message. So
+##   tags, and other rules only applies to the summary.  The body of the commit
+##   message will be displayed in the changelog without reformatting.
+
+
+##
+## ``ignore_regexps`` is a line of regexps
+##
+## Any commit having its full commit message matching any regexp listed here
+## will be ignored and won't be reported in the changelog.
+##
+ignore_regexps = [
+    r'@minor', r'!minor',
+    r'@cosmetic', r'!cosmetic',
+    r'@refactor', r'!refactor',
+    r'@wip', r'!wip',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[p|P]kg:',
+    r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*[d|D]ev:',
+    r'^(.{3,3}\s*:)?\s*[fF]irst commit.?\s*$',
+    r'^$',  ## ignore commits with empty messages
+]
+
+
+## ``section_regexps`` is a list of 2-tuples associating a string label and a
+## list of regexp
+##
+## Commit messages will be classified in sections thanks to this. Section
+## titles are the label, and a commit is classified under this section if any
+## of the regexps associated is matching.
+##
+## Please note that ``section_regexps`` will only classify commits and won't
+## make any changes to the contents. So you'll probably want to go check
+## ``subject_process`` (or ``body_process``) to do some changes to the subject,
+## whenever you are tweaking this variable.
+##
+section_regexps = [
+    ('New', [
+        r'^[nN]ew\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Changes', [
+        r'^[cC]hg\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+    ('Fix', [
+        r'^[fF]ix\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n]*)$',
+     ]),
+
+    ('Other', None ## Match all lines
+     ),
+
+]
+
+
+## ``body_process`` is a callable
+##
+## This callable will be given the original body and result will
+## be used in the changelog.
+##
+## Available constructs are:
+##
+##   - any python callable that take one txt argument and return txt argument.
+##
+##   - ReSub(pattern, replacement): will apply regexp substitution.
+##
+##   - Indent(chars="  "): will indent the text with the prefix
+##     Please remember that template engines gets also to modify the text and
+##     will usually indent themselves the text if needed.
+##
+##   - Wrap(regexp=r"\n\n"): re-wrap text in separate paragraph to fill 80-Columns
+##
+##   - noop: do nothing
+##
+##   - ucfirst: ensure the first letter is uppercase.
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - final_dot: ensure text finishes with a dot
+##     (usually used in the ``subject_process`` pipeline)
+##
+##   - strip: remove any spaces before or after the content of the string
+##
+##   - SetIfEmpty(msg="No commit message."): will set the text to
+##     whatever given ``msg`` if the current text is empty.
+##
+## Additionally, you can `pipe` the provided filters, for instance:
+#body_process = Wrap(regexp=r'\n(?=\w+\s*:)') | Indent(chars="  ")
+#body_process = Wrap(regexp=r'\n(?=\w+\s*:)')
+#body_process = noop
+body_process = ReSub(r'((^|\n)[A-Z]\w+(-\w+)*: .*(\n\s+.*)*)+$', r'') | strip
+
+
+## ``subject_process`` is a callable
+##
+## This callable will be given the original subject and result will
+## be used in the changelog.
+##
+## Available constructs are those listed in ``body_process`` doc.
+subject_process = (strip |
+    ReSub(r'^([cC]hg|[fF]ix|[nN]ew)\s*:\s*((dev|use?r|pkg|test|doc)\s*:\s*)?([^\n@]*)(@[a-z]+\s+)*$', r'\4') |
+    SetIfEmpty("No commit message.") | ucfirst | final_dot)
+
+
+## ``tag_filter_regexp`` is a regexp
+##
+## Tags that will be used for the changelog must match this regexp.
+##
+tag_filter_regexp = r'^[0-9]+\.[0-9]+(\.[0-9]+)?$'
+
+
+## ``unreleased_version_label`` is a string or a callable that outputs a string
+##
+## This label will be used as the changelog Title of the last set of changes
+## between last valid tag and HEAD if any.
+unreleased_version_label = "(unreleased)"
+
+
+## ``output_engine`` is a callable
+##
+## This will change the output format of the generated changelog file
+##
+## Available choices are:
+##
+##   - rest_py
+##
+##        Legacy pure python engine, outputs ReSTructured text.
+##        This is the default.
+##
+##   - mustache(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mustache/*.tpl``.
+##        Requires python package ``pystache``.
+##        Examples:
+##           - mustache("markdown")
+##           - mustache("restructuredtext")
+##
+##   - makotemplate(<template_name>)
+##
+##        Template name could be any of the available templates in
+##        ``templates/mako/*.tpl``.
+##        Requires python package ``mako``.
+##        Examples:
+##           - makotemplate("restructuredtext")
+##
+output_engine =  mustache("markdown.tpl")
+#output_engine = mustache("restructuredtext")
+#output_engine = mustache("markdown")
+#output_engine = makotemplate("restructuredtext")
+
+
+## ``include_merge`` is a boolean
+##
+## This option tells git-log whether to include merge commits in the log.
+## The default is to include them.
+include_merge = True
+
+
+## ``log_encoding`` is a string identifier
+##
+## This option tells gitchangelog what encoding is outputed by ``git log``.
+## The default is to be clever about it: it checks ``git config`` for
+## ``i18n.logOutputEncoding``, and if not found will default to git's own
+## default: ``utf-8``.
+#log_encoding = 'utf-8'
+
+
+## ``publish`` is a callable
+##
+## Sets what ``gitchangelog`` should do with the output generated by
+## the output engine. ``publish`` is a callable taking one argument
+## that is an interator on lines from the output engine.
+##
+## Some helper callable are provided:
+##
+## Available choices are:
+##
+##   - stdout
+##
+##        Outputs directly to standard output
+##        (This is the default)
+##
+##   - FileInsertAtFirstRegexMatch(file, pattern, idx=lamda m: m.start())
+##
+##        Creates a callable that will parse given file for the given
+##        regex pattern and will insert the output in the file.
+##        ``idx`` is a callable that receive the matching object and
+##        must return a integer index point where to insert the
+##        the output in the file. Default is to return the position of
+##        the start of the matched string.
+##
+##   - FileRegexSubst(file, pattern, replace, flags)
+##
+##        Apply a replace inplace in the given file. Your regex pattern must
+##        take care of everything and might be more complex. Check the README
+##        for a complete copy-pastable example.
+##
+# publish = FileInsertIntoFirstRegexMatch(
+#     "CHANGELOG.rst",
+#     r'/(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n/',
+#     idx=lambda m: m.start(1)
+# )
+#publish = stdout
+
+
+## ``revs`` is a list of callable or a list of string
+##
+## callable will be called to resolve as strings and allow dynamical
+## computation of these. The result will be used as revisions for
+## gitchangelog (as if directly stated on the command line). This allows
+## to filter exaclty which commits will be read by gitchangelog.
+##
+## To get a full documentation on the format of these strings, please
+## refer to the ``git rev-list`` arguments. There are many examples.
+##
+## Using callables is especially useful, for instance, if you
+## are using gitchangelog to generate incrementally your changelog.
+##
+## Some helpers are provided, you can use them::
+##
+##   - FileFirstRegexMatch(file, pattern): will return a callable that will
+##     return the first string match for the given pattern in the given file.
+##     If you use named sub-patterns in your regex pattern, it'll output only
+##     the string matching the regex pattern named "rev".
+##
+##   - Caret(rev): will return the rev prefixed by a "^", which is a
+##     way to remove the given revision and all its ancestor.
+##
+## Please note that if you provide a rev-list on the command line, it'll
+## replace this value (which will then be ignored).
+##
+## If empty, then ``gitchangelog`` will act as it had to generate a full
+## changelog.
+##
+## The default is to use all commits to make the changelog.
+#revs = ["^1.0.3", ]
+#revs = [
+#    Caret(
+#        FileFirstRegexMatch(
+#            "CHANGELOG.rst",
+#            r"(?P<rev>[0-9]+\.[0-9]+(\.[0-9]+)?)\s+\([0-9]+-[0-9]{2}-[0-9]{2}\)\n--+\n")),
+#    "HEAD"
+#]
+revs = []

--- a/gitchangelog/markdown.tpl
+++ b/gitchangelog/markdown.tpl
@@ -1,0 +1,20 @@
+{{#general_title}}
+# {{{title}}}
+
+{{/general_title}}
+{{#versions}}
+
+{{#sections}}
+### {{{label}}}
+
+{{#commits}}
+* {{{subject}}} [{{{author}}}]
+{{#body}}
+
+{{{body_indented}}}
+{{/body}}
+
+{{/commits}}
+{{/sections}}
+
+{{/versions}}

--- a/release_bot/cli.py
+++ b/release_bot/cli.py
@@ -18,12 +18,17 @@ import logging
 from pathlib import Path
 
 from release_bot.configuration import configuration
+from release_bot.exceptions import ReleaseException
 
 
 class CLI:
+
     @staticmethod
     def parse_arguments():
-        """Parse application arguments"""
+        """
+        Parse application arguments
+        :return args:
+        """
         parser = argparse.ArgumentParser(description="Automatic releases bot", prog='release-bot')
         parser.add_argument("-d", "--debug", help="turn on debugging output",
                             action="store_true", default=False)
@@ -34,15 +39,28 @@ class CLI:
         parser.add_argument("-n", "--dry-run", default=False,
                             help="Don’t change anything, just show what would be done.",
                             action="store_true")
+        parser.set_defaults(subcommand="none")
+
+        subparsers = parser.add_subparsers()
+        parser_init = subparsers.add_parser('init',
+                                            help='Initializes the repository for the release-bot')
+        parser_init.set_defaults(subcommand="run_init")
+        parser_init.add_argument("-s", "--silent", help="Runs the init in non-interactive way",
+                                 action="store_true", default=False)
 
         args = parser.parse_args()
+        return args
 
+    @staticmethod
+    def get_configuration(args):
+        """
+        Get the bot's configuration using the args
+        """
         if args.configuration:
             args.configuration = Path(args.configuration).resolve()
             if not args.configuration.is_file():
-                configuration.logger.error(
+                raise ReleaseException(
                     f"Supplied configuration file is not found: {args.configuration}")
-                exit(1)
 
         if args.debug:
             configuration.logger.setLevel(logging.DEBUG)

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -38,6 +38,7 @@ class Configuration:
         self.debug = False
         self.configuration = ''
         self.logger = None
+        self.init = False
         self.set_logging()
         self.dry_run = False
         # used when PyPI project name != repository name
@@ -125,6 +126,7 @@ class Configuration:
         # If pypi option is not specified in release-conf.yaml,
         # it defaults to true.
         parsed_conf.setdefault('pypi', True)
+        parsed_conf.setdefault('gitchangelog', False)
 
         parsed_conf = {k: v for (k, v) in parsed_conf.items() if v}
         for item in self.REQUIRED_ITEMS['release-conf']:

--- a/release_bot/git.py
+++ b/release_bot/git.py
@@ -47,13 +47,17 @@ class Git:
             raise GitException(f"Can't clone repository {url}")
         return temp_directory
 
-    def get_log_since_last_release(self, latest_version):
+    def get_log_since_last_release(self, latest_version, gitchangelog):
         """
-        Utilizes git log to get log since last release, excluding merge commits
+        Utilizes [GitChangeLog](https://github.com/vaab/gitchangelog/) to get
+        log since latest release according to the template provided.
         :param latest_version: previous version
         :return: changelog or placeholder
         """
-        cmd = f'git log {latest_version}... --no-merges --format=\'* %s\''
+        if gitchangelog:
+            cmd = f'gitchangelog ^{latest_version} HEAD'
+        else:
+            cmd = f'git log {latest_version}... --no-merges --format=\'* %s\''
         success, changelog = run_command_get_output(self.repo_path, cmd)
         return changelog if success and changelog else 'No changelog provided'
 

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -415,7 +415,7 @@ class Github:
                    f"PR on github:\n{response.text}")
             raise ReleaseException(msg)
 
-    def make_release_pr(self, new_pr):
+    def make_release_pr(self, new_pr, gitchangelog):
         """
         Makes the steps to prepare new branch for the release PR,
         like generating changelog and updating version
@@ -442,7 +442,7 @@ class Github:
             # This makes sure that the new release_pr branch has all the commits
             # from the master branch for the lastest release.
             repo.checkout('master')
-            changelog = repo.get_log_since_last_release(new_pr.previous_version)
+            changelog = repo.get_log_since_last_release(new_pr['previous_version'], gitchangelog)
             repo.checkout_new_branch(branch)
             changed = look_for_version_files(repo.repo_path, new_pr.version)
             if insert_in_changelog(f'{repo.repo_path}/CHANGELOG.md',

--- a/release_bot/init_repo.py
+++ b/release_bot/init_repo.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This module initializes a repo to be used by ReleaseBot
+"""
+import os
+import yaml
+
+from release_bot.utils import run_command_get_output
+
+TEMPLATE_STRING = """{{#general_title}}
+# {{{title}}}
+
+{{/general_title}}
+{{#versions}}
+
+{{#sections}}
+### {{{label}}}
+
+{{#commits}}
+* {{{subject}}} [{{{author}}}]
+{{#body}}
+
+{{{body_indented}}}
+{{/body}}
+
+{{/commits}}
+{{/sections}}
+
+{{/versions}}"""
+
+GITCHANGELOG_RC_STRING = """
+output_engine =  mustache("markdown.tpl")
+"""
+
+class Init:
+    """
+    Creates all of the required configuration script required for the ReleaseBot
+    """
+    def __init__(self):
+        self.conf = {
+            'repository_name': '<repository_name>',
+            'repository_owner': '<owner_of_repository>',
+            'github_token': '<your_github_token>',
+            'refresh_interval': '180',
+            'github_username': '<your_github_username>',
+        }
+        self.release_conf = {
+            'trigger_on_issue': True,
+            'gitchangelog': True,
+            'author_email': '<your_email>',
+            'author_name': '<your_name>',
+            'labels': []
+        }
+
+    def run(self, silent):
+        """
+        Performs all the init tasks
+        """
+        self.create_conf(silent)
+        self.append_to_gitignore()
+        if self.release_conf['gitchangelog']:
+            self.create_template()
+            self.create_gitchangelog_rc()
+        if silent:
+            conclude = """Successfully initialized the repository
+Please first modify all value with '< >' in the release.conf.
+Then commit all of the changes made to the repo and
+from shell run 'release-bot -c conf.yaml"""
+        else:
+            conclude = """Successfully initialized the repository
+Please commit all of the changes made to the repo and
+from shell run 'release-bot -c conf.yaml'"""
+
+        print(conclude)
+
+
+    def create_conf(self, silent):
+        """
+        Create the release-conf.yaml and conf.yaml
+        """
+        cwd = os.getcwd()
+        self.release_conf['author_email'] = run_command_get_output(cwd, f'git config user.email')[1]
+        self.release_conf['author_name'] = run_command_get_output(cwd, f'git config user.name')[1]
+
+        if not silent:
+            self.conf['repository_name'] = input('Please enter the repository name:')
+            self.conf['repository_owner'] = input('Please enter the repository owner:')
+            print("""For details on how to get github token checkout
+    'https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/'""")
+            self.conf['github_token'] = input('Please enter your valid github token:')
+            refresh_interval = input("""In how many seconds would you like the
+    bot to check for updates (Default 180):""")
+            if refresh_interval:
+                self.conf['refresh_interval'] = int(refresh_interval)
+            else:
+                self.conf['refresh_interval'] = 180
+            is_owner_user = input('Are you the owner of the repo? (Y/n):')
+            if is_owner_user.lower() == 'y' or is_owner_user == '':
+                self.conf['github_username'] = self.conf['repository_owner']
+            else:
+                self.conf['github_username'] = input('Please enter your github usename:')
+            trigger_on_issue = input('Would you like to trigger release from issue? (Y/n):')
+            self.release_conf['trigger_on_issue'] = bool(
+                trigger_on_issue.lower() == 'y' or trigger_on_issue == ''
+            )
+            gitchangelog = input(
+                'Would you like to use gitchangelog to generate next-gen changelogs? (Y/n):'
+                )
+            self.release_conf['gitchangelog'] = bool(
+                gitchangelog.lower() == 'y' or gitchangelog == ''
+                )
+
+        self.create_yaml(self.conf, 'conf.yaml')
+        self.create_yaml(self.release_conf, 'release-conf.yaml')
+
+    @staticmethod
+    def append_to_gitignore():
+        """
+        Append conf.yaml to the gitignore
+        """
+        with open('.gitignore', 'a+') as gitignore_file:
+            gitignore_file.write('\nconf.yaml')
+
+
+    @staticmethod
+    def create_yaml(_dict, file_name):
+        """
+        Create or overwrite yaml file
+        :param dict: dict to be converted to yaml
+        :param filename: name of the yaml file to create
+        """
+        def dump_yaml():
+            """
+            Dumps the yaml into the file
+            """
+            with open(file_name, 'w') as yaml_file:
+                yaml.safe_dump(_dict, yaml_file, default_flow_style=False)
+
+        if not os.path.isfile(file_name):
+            dump_yaml()
+        else:
+            should_overrite = input(
+                file_name+" already exists, would you like to overwrite it? (y/N):"
+                )
+            if should_overrite.lower() == 'y':
+                dump_yaml()
+
+    @staticmethod
+    def create_template():
+        """
+        Creates template file for the Markdown output
+        """
+        with open('markdown.tpl', 'w') as template_file:
+            template_file.write(TEMPLATE_STRING)
+
+    @staticmethod
+    def create_gitchangelog_rc():
+        """
+        Creates the .gitchangelog.rc file for the git change log config
+        """
+        with open('.gitchangelog.rc', 'w') as gitchangelog_rc_file:
+            gitchangelog_rc_file.write(GITCHANGELOG_RC_STRING)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -315,8 +315,8 @@ def main():
     else:
         CLI.get_configuration(args)
         configuration.load_configuration()
-    	rb = ReleaseBot(configuration)
-    	if configuration.webhook_handler:
+        rb = ReleaseBot(configuration)
+        if configuration.webhook_handler:
             rb.create_flask_instance()
         else:
             rb.run()

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -310,7 +310,7 @@ class ReleaseBot:
 def main():
     args = CLI.parse_arguments()
     if args.subcommand == "run_init":
-        ingitit_repo = Init()
+        init_repo = Init()
         init_repo.run(args.silent)
     else:
         CLI.get_configuration(args)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -34,6 +34,7 @@ from release_bot.utils import process_version_from_title
 from release_bot.new_release import NewRelease
 from release_bot.new_pr import NewPR
 from release_bot.webhooks import GithubWebhooksHandler
+from release_bot.init_repo import Init
 
 
 class ReleaseBot:
@@ -198,7 +199,8 @@ class ReleaseBot:
             self.new_pr.repo = self.git
             if not self.new_pr.repo:
                 raise ReleaseException("Couldn't clone repository!")
-            if self.github.make_release_pr(self.new_pr):
+            gitchangelog = self.new_release.get('gitchangelog')
+            if self.github.make_release_pr(self.new_pr, gitchangelog):
                 pr_handler(success=True)
                 return True
         except ReleaseException:
@@ -306,14 +308,18 @@ class ReleaseBot:
 
 
 def main():
-    CLI.parse_arguments()
-    configuration.load_configuration()
-
-    rb = ReleaseBot(configuration)
-    if configuration.webhook_handler:
-        rb.create_flask_instance()
+    args = CLI.parse_arguments()
+    if args.subcommand == "run_init":
+        ingitit_repo = Init()
+        init_repo.run(args.silent)
     else:
-        rb.run()
+        CLI.get_configuration(args)
+        configuration.load_configuration()
+    	rb = ReleaseBot(configuration)
+    	if configuration.webhook_handler:
+            rb.create_flask_instance()
+        else:
+            rb.run()
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ twine
 wheel
 PyJWT
 flask
+gitchangelog
+pystache


### PR DESCRIPTION
This PR is still incomplete!
Solves #91  

To test this, copy gitchangelog/.gitchangelog.rc and gitchangelog/markdown.tpl into the the root dir of the project. 

I need some help from maintainers regarding the following points to complete this pr:

* How should I include the the not python files (.gitchangelog.rc and template.tpl) into the package and automatically copy it using python to the repo. (This would help in solving #168 also)

* How should the change log look like by default? This would help me create the template for the gitchangelog and also currently the changelogs are divided into parts[(New, Changes, Fix, Others)](https://github.com/vaab/gitchangelog/edit/master/README.rst#L141-L176) Do we need that?

sidenote: I have also included the commits from my previous [PR](https://github.com/user-cont/release-bot/pull/174) because that bug was creating a problem in GitChangeLog implementation.  