### PR TITLE
Added the dry-run functionality.

### DIFF
--- a/release_bot/cli.py
+++ b/release_bot/cli.py
@@ -31,6 +31,9 @@ class CLI:
                             default='')
         parser.add_argument("-v", "--version", help="display program version", action='version',
                             version=f"%(prog)s {configuration.version}")
+        parser.add_argument("-n", "--dry-run", default=False,
+                            help="Don’t change anything, just show what would be done.",
+                            action="store_true")
 
         args = parser.parse_args()
 
@@ -45,3 +48,4 @@ class CLI:
             configuration.logger.setLevel(logging.DEBUG)
         for key, value in vars(args).items():
             setattr(configuration, key, value)
+        configuration.dry_run = args.dry_run

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -38,6 +38,7 @@ class Configuration:
         self.configuration = ''
         self.logger = None
         self.set_logging()
+        self.dry_run = False
         # configuration when bot is deployed as github app
         self.github_app_installation_id = ''
         self.github_app_id = ''

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -174,7 +174,7 @@ class Github:
             return
         if self.conf.dry_run:
             self.logger.info("I would add a comment to the pull request created.")
-            return "SKIPPED"
+            return None
         comment = '\n'.join(self.comment)
         mutation = (f'mutation {{addComment(input:'
                     f'{{subjectId: "{subject_id}", body: "{comment}"}})' +
@@ -528,7 +528,7 @@ class Github:
         """
         if self.conf.dry_run:
             self.logger.info("I would add labels to issue #%s", number)
-            return "SKIPPED"
+            return False
         payload = {'labels': labels}
         url = (f"{self.API3_ENDPOINT}repos/{self.conf.repository_owner}/"
                f"{self.conf.repository_name}/issues/{number}")

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -174,7 +174,7 @@ class Github:
             return
         if self.conf.dry_run:
             self.logger.info("I would add a comment to the pull request created.")
-            return
+            return "SKIPPED"
         comment = '\n'.join(self.comment)
         mutation = (f'mutation {{addComment(input:'
                     f'{{subjectId: "{subject_id}", body: "{comment}"}})' +
@@ -432,7 +432,7 @@ class Github:
             msg = (f"I would make a new PR for release of version "
                    f"{version} based on the issue.")
             self.logger.info(msg)
-            return
+            return False
         try:
             name, email = self.get_user_contact()
             repo.set_credentials(name, email)
@@ -528,7 +528,7 @@ class Github:
         """
         if self.conf.dry_run:
             self.logger.info("I would add labels to issue #%s", number)
-            return
+            return "SKIPPED"
         payload = {'labels': labels}
         url = (f"{self.API3_ENDPOINT}repos/{self.conf.repository_owner}/"
                f"{self.conf.repository_name}/issues/{number}")

--- a/release_bot/pypi.py
+++ b/release_bot/pypi.py
@@ -97,7 +97,7 @@ class PyPi:
             self.build_sdist(project_root)
             self.build_wheel(project_root)
             if self.conf.dry_run:
-                return "SKIPPED"
+                return False
             self.upload(project_root)
         else:
             raise ReleaseException("Cannot find project root for PyPi release:")

--- a/release_bot/pypi.py
+++ b/release_bot/pypi.py
@@ -96,6 +96,7 @@ class PyPi:
             self.logger.debug("About to release on PyPi")
             self.build_sdist(project_root)
             self.build_wheel(project_root)
-            self.upload(project_root)
+            if not self.conf.dry_run:
+                self.upload(project_root)
         else:
             raise ReleaseException("Cannot find project root for PyPi release:")

--- a/release_bot/pypi.py
+++ b/release_bot/pypi.py
@@ -96,7 +96,8 @@ class PyPi:
             self.logger.debug("About to release on PyPi")
             self.build_sdist(project_root)
             self.build_wheel(project_root)
-            if not self.conf.dry_run:
-                self.upload(project_root)
+            if self.conf.dry_run:
+                return "SKIPPED"
+            self.upload(project_root)
         else:
             raise ReleaseException("Cannot find project root for PyPi release:")

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -225,7 +225,7 @@ class ReleaseBot:
         else:
             try:
                 if self.conf.dry_run:
-                    return "SKIPPED"
+                    return None
                 released, self.new_release = self.github.make_new_release(self.new_release)
                 if released:
                     release_handler(success=True)
@@ -257,8 +257,8 @@ class ReleaseBot:
         self.git.fetch_tags()
         self.git.checkout(self.new_release.version)
         try:
-            if self.pypi.release() == "SKIPPED":
-            	return "SKIPPED"
+            if self.pypi.release() == False:
+                return False
             release_handler(success=True)
         except ReleaseException:
             release_handler(success=False)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -225,7 +225,7 @@ class ReleaseBot:
         else:
             try:
                 if self.conf.dry_run:
-                    return
+                    return "SKIPPED"
                 released, self.new_release = self.github.make_new_release(self.new_release)
                 if released:
                     release_handler(success=True)
@@ -257,7 +257,8 @@ class ReleaseBot:
         self.git.fetch_tags()
         self.git.checkout(self.new_release.version)
         try:
-            self.pypi.release()
+            if self.pypi.release() == "SKIPPED":
+            	return "SKIPPED"
             release_handler(success=True)
         except ReleaseException:
             release_handler(success=False)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -189,14 +189,15 @@ class ReleaseBot:
             msg = f"Version ({latest_gh_str}) is already released and this issue is ignored."
             self.logger.warning(msg)
             return False
-        msg = f"Making a new PR for release of version {self.new_pr.version} based on an issue."
-        self.logger.info(msg)
+        msg = (f"Making a new PR for release of version "
+               f"{self.new_pr.version} based on the issue.")
+        if not self.conf.dry_run:
+            self.logger.info(msg)
 
         try:
             self.new_pr.repo = self.git
             if not self.new_pr.repo:
                 raise ReleaseException("Couldn't clone repository!")
-
             if self.github.make_release_pr(self.new_pr):
                 pr_handler(success=True)
                 return True
@@ -223,6 +224,8 @@ class ReleaseBot:
                 f"{self.new_release.version} has already been released on Github")
         else:
             try:
+                if self.conf.dry_run:
+                    return
                 released, self.new_release = self.github.make_new_release(self.new_release)
                 if released:
                     release_handler(success=True)
@@ -239,7 +242,10 @@ class ReleaseBot:
 
         def release_handler(success):
             result = "released" if success else "failed to release"
-            msg = f"I just {result} version {self.new_release.version} on PyPI"
+            if self.conf.dry_run:
+                msg = f"I would have {result} version {self.new_release.version} on PyPI now."
+            else:
+                msg = f"I just {result} version {self.new_release.version} on PyPI"
             level = logging.INFO if success else logging.ERROR
             self.logger.log(level, msg)
             self.github.comment.append(msg)
@@ -263,6 +269,8 @@ class ReleaseBot:
 
     def run(self):
         self.logger.info(f"release-bot v{configuration.version} reporting for duty!")
+        if self.conf.dry_run:
+            self.logger.info("Running in dry-run mode.")
         try:
             while True:
                 self.git.pull()

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -81,6 +81,10 @@ class TestBot:
         )
         self.g_utils.open_issue("0.0.1 release")
         self.release_bot.find_open_release_issues()
+        # Testing dry-run mode
+        self.release_bot.conf.dry_run = True
+        assert not self.release_bot.make_release_pull_request()
+        self.release_bot.conf.dry_run = False
         self.release_bot.make_release_pull_request()
         pr_number = self.release_bot.github.pr_exists("0.0.1 release")
         assert pr_number and self.g_utils.merge_pull_request(pr_number)
@@ -135,12 +139,20 @@ class TestBot:
     def test_github_release(self, open_pr_fixture):
         """Tests releasing on Github"""
         assert self.release_bot.find_newest_release_pull_request()
+        # Testing dry-run mode
+        self.release_bot.conf.dry_run = True
+        assert self.release_bot.make_new_github_release() == "SKIPPED"
+        self.release_bot.conf.dry_run = False
         self.release_bot.make_new_github_release()
         assert self.release_bot.github.latest_release() == "0.0.1"
 
     def test_pypi_release(self, mock_upload, github_release):
         """Test PyPi release"""
         self.release_bot.load_release_conf()
+        # Testing dry-run mode
+        self.release_bot.conf.dry_run = True
+        assert self.release_bot.make_new_pypi_release() == "SKIPPED"
+        self.release_bot.conf.dry_run = False
         assert self.release_bot.make_new_pypi_release()
         path = Path(self.release_bot.git.repo_path)
         assert list(path.glob(f'dist/release_bot_test_{self.g_utils.random_string}-0.0.1-py3*.whl'))

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -141,7 +141,7 @@ class TestBot:
         assert self.release_bot.find_newest_release_pull_request()
         # Testing dry-run mode
         self.release_bot.conf.dry_run = True
-        assert self.release_bot.make_new_github_release() == "SKIPPED"
+        assert self.release_bot.make_new_github_release() is None
         self.release_bot.conf.dry_run = False
         self.release_bot.make_new_github_release()
         assert self.release_bot.github.latest_release() == "0.0.1"
@@ -151,7 +151,7 @@ class TestBot:
         self.release_bot.load_release_conf()
         # Testing dry-run mode
         self.release_bot.conf.dry_run = True
-        assert self.release_bot.make_new_pypi_release() == "SKIPPED"
+        assert not self.release_bot.make_new_pypi_release()
         self.release_bot.conf.dry_run = False
         assert self.release_bot.make_new_pypi_release()
         path = Path(self.release_bot.git.repo_path)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -96,7 +96,7 @@ class TestGithub:
         comments_count = self.g_utils.count_comments(number)
         self.github.comment = "Test comment"
         self.github.conf.dry_run = True
-        assert self.github.add_comment(graphql_id) == "SKIPPED"
+        assert self.github.add_comment(graphql_id) is None
         self.github.conf.dry_run = False
         self.github.add_comment(graphql_id)
         assert self.g_utils.count_comments(number) == comments_count + 1

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -95,5 +95,8 @@ class TestGithub:
         number, graphql_id = open_issue_graphql
         comments_count = self.g_utils.count_comments(number)
         self.github.comment = "Test comment"
+        self.github.conf.dry_run = True
+        assert self.github.add_comment(graphql_id) == "SKIPPED"
+        self.github.conf.dry_run = False
         self.github.add_comment(graphql_id)
         assert self.g_utils.count_comments(number) == comments_count + 1


### PR DESCRIPTION
It can be triggered by the argument `-n` or `--dryrun`.

I have not changed the info messages which are printed out. I have just skipped all the remote operations (which can cause a change, like commenting, adding a tag to the issue, making a PR). The reason behind this was mainly to simulate the run through of the release-bot, instead of making any remote change.

Solves #171 