### PR TITLE
delete s2i check for pypi configuration

### DIFF
--- a/.s2i-dev/bin/assemble
+++ b/.s2i-dev/bin/assemble
@@ -4,12 +4,6 @@ shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
-# check for PyPi conf
-if [ ! -f ./.pypirc ]; then
-    echo "ERROR: no PyPi configuration found"
-    exit 1
-fi
-
 # check for bot conf
 if [ ! -f ./conf.yaml ]; then
     echo "ERROR: no bot configuration found"

--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -4,12 +4,6 @@ shopt -s dotglob
 echo "---> Installing application source ..."
 mv /tmp/src/* ./
 
-# check for PyPi conf
-if [ ! -f ./.pypirc ]; then
-    echo "ERROR: no PyPi configuration found"
-    exit 1
-fi
-
 # check for bot conf
 if [ ! -f ./conf.yaml ]; then
     echo "ERROR: no bot configuration found"


### PR DESCRIPTION
According to merged PR #165, there is no longer a need for check PyPi configuration file. This is a fix for  `ERROR: no PyPi configuration found` produced by s2i when `.pypirc` is not found. 