### PR TITLE
Add new configuration option to specify clone url.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,9 @@ __pycache__/
 # Unit test / coverage reports
 .cache
 
-# PyCharm
-.idea/
-
 .pytest_cache/
+
+# Editors and IDEs
+.idea/
+.vscode/
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Here are the `conf.yaml` configuration options:
 | `github_app_id`              | ID (a number) of the Github app. | No |
 | `github_app_cert_path`       | Path to a certificate which Github provides as an auth mechanism for Github apps. | No |
 | `refresh_interval`           | Time in seconds between checks on repository. Default is 180 | No |
+| `clone_url`                  | URL used to clone your Github repository. By default, `https` variant is used. | No |
 
 Sample config named [conf.yaml](conf.yaml) can be found in this repository.
 
@@ -123,6 +124,9 @@ so you can keep track of what changes were made by bot and what are your own.
 You can also create a Github app and use it as an authentication mechanism for
 the bot. For that you need to specify the three config values prefixed with
 `github_app`.
+
+**Note:** If the Upstream repository is a [Private Github repository](https://help.github.com/en/articles/setting-repository-visibility#about-repository-visibility), it is required to specify the SSH URL
+of the repository as the `clone_url` option in `conf.yaml`. This will allow the bot to authenticate using SSH, when fetching from the Upstream repository.
 
 ## Upstream repository
 

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -96,6 +96,10 @@ class Configuration:
             if item not in file:
                 self.logger.error(f"Item {item!r} is required in configuration!")
                 sys.exit(1)
+        # if user hasn't specified clone_url, use default
+        if 'clone_url' not in file:
+            self.clone_url = (f'https://github.com/{self.repository_owner}'
+                              f'/{self.repository_name}.git')
         self.logger.debug(f"Loaded configuration for {self.repository_owner}/{self.repository_name}")
 
     def load_release_conf(self, conf):

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -42,6 +42,7 @@ class Configuration:
         self.github_app_installation_id = ''
         self.github_app_id = ''
         self.github_app_cert_path = ''
+        self.clone_url = ''
 
     def set_logging(self,
                     logger_name="release-bot",

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -36,7 +36,11 @@ class ReleaseBot:
 
     def __init__(self, configuration):
         self.conf = configuration
-        url = f'https://github.com/{self.conf.repository_owner}/{self.conf.repository_name}.git'
+        # If the user specifies an URL, use it. Otherwise use the default URL
+        if self.conf.clone_url:
+            url = self.conf.clone_url
+        else:
+            url = f'https://github.com/{self.conf.repository_owner}/{self.conf.repository_name}.git'
         self.git = Git(url, self.conf)
         self.github = Github(configuration, self.git)
         self.pypi = PyPi(configuration, self.git)

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -36,12 +36,7 @@ class ReleaseBot:
 
     def __init__(self, configuration):
         self.conf = configuration
-        # If the user specifies an URL, use it. Otherwise use the default URL
-        if self.conf.clone_url:
-            url = self.conf.clone_url
-        else:
-            url = f'https://github.com/{self.conf.repository_owner}/{self.conf.repository_name}.git'
-        self.git = Git(url, self.conf)
+        self.git = Git(self.conf.clone_url, self.conf)
         self.github = Github(configuration, self.git)
         self.pypi = PyPi(configuration, self.git)
         self.logger = configuration.logger

--- a/tests/src/conf_with_clone_url.yaml
+++ b/tests/src/conf_with_clone_url.yaml
@@ -1,0 +1,6 @@
+repository_name: random_repo
+repository_owner: repo_owner
+github_token: XXXXXXXXXXXXXXXXXXXXXX
+github_username: random_user
+refresh_interval: 60
+clone_url: https://github.com/test/url.git

--- a/tests/src/sample_conf.yaml
+++ b/tests/src/sample_conf.yaml
@@ -1,0 +1,4 @@
+repository_name: random_repo
+repository_owner: repo_owner
+github_token: XXXXXXXXXXXXXXXXXXXXXX
+github_username: random_user

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -45,6 +45,7 @@ class TestBot:
         configuration.repository_name = self.g_utils.repo
         configuration.repository_owner = self.github_user
         configuration.github_username = self.github_user
+        configuration.clone_url = f'https://github.com/{self.github_user}/{self.g_utils.repo}.git'
         configuration.refresh_interval = 1
 
         self.release_bot = ReleaseBot(configuration)

--- a/tests/test_load_local_conf.py
+++ b/tests/test_load_local_conf.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from pathlib import Path
+from release_bot.configuration import configuration
+
+
+class TestLoadLocalConf:
+    """ This class contains tests for loading the release-bot
+    configuration from conf.yaml"""
+
+
+    def setup_method(self):
+        """ Setup any state tied to the execution of the given method in a
+        class. setup_method is invoked for every test method of a class.
+        """
+        configuration.set_logging(level=10)
+        configuration.debug = True
+
+    def teardown_method(self, method):
+        """ Teardown any state that was previously setup with a setup_method
+        call.
+        """
+
+    @pytest.fixture
+    def conf_with_clone_url(self):
+        """Returns a valid configuration with clone_url option"""
+        return Path(__file__).parent / "src/conf_with_clone_url.yaml"
+
+    @pytest.fixture
+    def sample_conf(self):
+        """Return a sample configuration file"""
+        return Path(__file__).parent / "src/sample_conf.yaml"
+
+    @pytest.fixture
+    def non_existing_conf(self):
+        """Return a non-existing configutation file"""
+        return ""
+
+    def test_non_existing_conf(self, non_existing_conf):
+        """Test if missing conf.yaml generates an error"""
+        configuration.configuration = non_existing_conf
+        with pytest.raises(SystemExit) as error:
+            configuration.load_configuration()
+        assert error.type == SystemExit
+        assert error.value.code == 1    
+
+    def test_conf_with_clone_url(self, conf_with_clone_url):
+        """Tests if the user-defined clone_url is loaded"""
+        configuration.configuration = conf_with_clone_url
+        configuration.load_configuration()
+        assert configuration.clone_url == 'https://github.com/test/url.git'
+
+    def test_conf_without_clone_url(self, sample_conf):
+        """Tests if default clone_url is used when not specified in conf.yaml"""
+        configuration.configuration = sample_conf
+        configuration.load_configuration()
+        assert configuration.clone_url == 'https://github.com/repo_owner/random_repo.git'
+
+    def test_missing_required_items(self, sample_conf):
+        """Tests if missing requied items generate an error"""
+        old_value = configuration.REQUIRED_ITEMS['conf']
+        configuration.REQUIRED_ITEMS['conf'] = ['test-key']
+        configuration.configuration = sample_conf
+        with pytest.raises(SystemExit) as error:
+            configuration.load_configuration()
+        configuration.REQUIRED_ITEMS['conf'] = old_value
+        assert error.type == SystemExit
+        assert error.value.code == 1


### PR DESCRIPTION
Added configuration option `clone_url`,  that
allows the user to explicitly specify the URL of the
repository to be cloned.

Fixes #179