### PR TITLE
implementation of Github webhooks handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora:29
 
+EXPOSE 8080
+
 ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i \
     STI_SCRIPTS_PATH=/usr/libexec/s2i \
     # The $HOME is not set by default, but some applications needs this variable

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM registry.fedoraproject.org/fedora:29
 
+EXPOSE 8080
+
 ENV STI_SCRIPTS_URL=image:///usr/libexec/s2i \
     STI_SCRIPTS_PATH=/usr/libexec/s2i \
     # The $HOME is not set by default, but some applications needs this variable

--- a/openshift-template-dev.yml
+++ b/openshift-template-dev.yml
@@ -88,6 +88,9 @@ objects:
           containers :
             - name : ${APP_NAME}
               image : ${APP_NAME}:latest
+              ports:
+                - containerPort: 8080
+                  protocol: TCP
               resources:
                 requests:
                   memory: "64Mi"
@@ -95,6 +98,34 @@ objects:
                 limits:
                   memory: "128Mi"
                   cpu: "100m"
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: release-bot
+      labels:
+         application: release-bot
+      annotations:
+        description: Exposes release-bot port for github webhook callbacks
+    spec:
+      ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        deploymentconfig: ${APP_NAME}
+  - kind: Route
+    apiVersion: v1
+    metadata:
+      name: release-bot
+      labels:
+         application: release-bot
+      annotations:
+        description: Github webhook route to reach release-bot
+    spec:
+      to:
+        kind: Service
+        name: release-bot
 
 parameters :
   - name : APP_NAME

--- a/openshift-template.yml
+++ b/openshift-template.yml
@@ -88,6 +88,9 @@ objects:
           containers :
             - name : ${APP_NAME}
               image : ${APP_NAME}:latest
+              ports:
+                - containerPort: 8080
+                  protocol: "TCP"
               resources:
                 requests:
                   memory: "64Mi"
@@ -95,6 +98,34 @@ objects:
                 limits:
                   memory: "128Mi"
                   cpu: "100m"
+  - kind: Service
+    apiVersion: v1
+    metadata:
+      name: release-bot
+      labels:
+         application: release-bot
+      annotations:
+        description: Exposes release-bot port for github webhook callbacks
+    spec:
+      ports:
+        - name: 8080-tcp
+          port: 8080
+          protocol: TCP
+          targetPort: 8080
+      selector:
+        deploymentconfig: ${APP_NAME}
+  - kind: Route
+    apiVersion: v1
+    metadata:
+      name: release-bot
+      labels:
+         application: release-bot
+      annotations:
+        description: Github webhook route to reach release-bot
+    spec:
+      to:
+        kind: Service
+        name: release-bot
 
 parameters :
   - name : APP_NAME

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -43,6 +43,7 @@ class Configuration:
         self.github_app_id = ''
         self.github_app_cert_path = ''
         self.clone_url = ''
+        self.webhook_handler = False
 
     def set_logging(self,
                     logger_name="release-bot",

--- a/release_bot/webhooks.py
+++ b/release_bot/webhooks.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This module is backend for WSGI.
+"""
+from flask import request, jsonify
+from flask.views import View
+
+from release_bot.exceptions import ReleaseException
+
+
+class GithubWebhooksHandler(View):
+    """
+        Handler for github callbacks.
+    """
+
+    def __init__(self, release_bot, conf):
+        self.release_bot = release_bot
+        self.conf = conf
+        self.logger = conf.logger
+
+    def dispatch_request(self):
+        self.logger.info(f'New github webhook call from '
+                         f'{self.conf.repository_owner}/{self.conf.repository_name}')
+        if request.is_json:
+            self.parse_payload(request.get_json())
+        else:
+            self.logger.error("This webhook doesn't contain JSON")
+        return jsonify(result={"status": 200})
+
+    def parse_payload(self, webhook_payload):
+        """
+        Parse json webhook payload callback
+        :param webhook_payload: json from github webhook
+        """
+        self.logger.info(f"release-bot v{self.conf.version} reporting for duty!")
+        if 'issue' in webhook_payload.keys():
+            if webhook_payload['action'] == 'opened':
+                self.handle_issue()
+        elif 'pull_request' in webhook_payload.keys():
+            if webhook_payload['action'] == 'closed':
+                if webhook_payload['pull_request']['merged'] is True:
+                    self.handle_pr()
+        else:
+            self.logger.info("This webhook doesn't contain opened issue or merged PR")
+        self.logger.debug("Done. Waiting for another github webhook callback")
+
+    def handle_issue(self):
+        """Handler for newly opened issues"""
+        self.logger.info("Resolving opened issue")
+        self.release_bot.git.pull()
+        try:
+            self.release_bot.load_release_conf()
+            if (self.release_bot.new_release.get('trigger_on_issue') and
+                    self.release_bot.find_open_release_issues()):
+                if self.release_bot.new_release.get('labels') is not None:
+                    self.release_bot.github.put_labels_on_issue(
+                        self.release_bot.new_pr['issue_number'],
+                        self.release_bot.new_release.get('labels'))
+                self.release_bot.make_release_pull_request()
+        except ReleaseException as exc:
+            self.logger.error(exc)
+
+    def handle_pr(self):
+        """Handler for merged PR"""
+        self.logger.info("Resolving opened PR")
+        self.release_bot.git.pull()
+        try:
+            self.release_bot.load_release_conf()
+            if self.release_bot.find_newest_release_pull_request():
+                self.release_bot.make_new_github_release()
+                # Try to do PyPi release regardless whether we just did github release
+                # for case that in previous iteration (of the 'while True' loop)
+                # we succeeded with github release, but failed with PyPi release
+                self.release_bot.make_new_pypi_release()
+        except ReleaseException as exc:
+            self.logger.error(exc)
+        self.release_bot.github.add_comment(self.release_bot.new_release.get('pr_id'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ semantic_version
 twine
 wheel
 PyJWT
+flask

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+from flask import Flask
+from flexmock import flexmock
+import json
+
+from release_bot.webhooks import GithubWebhooksHandler
+
+
+@pytest.fixture()
+def flask_instance():
+    """
+    Create flask instance for tests.
+    Mock all necessary dependencies.
+    :return: flask instance for tests
+    """
+
+    release_bot = flexmock()
+    configuration = flexmock(
+        logger=flexmock(),
+        repository_owner='repo-owner',
+        repository_name='repo-name',
+        version="0.0.0"
+    )
+
+    flexmock(
+        configuration.logger,
+        info="info",
+        error="error",
+        debug="debug")
+
+    app = Flask(__name__)
+    app.add_url_rule('/webhook-handler/',
+                     view_func=GithubWebhooksHandler.as_view('github_webhooks_handler',
+                                                             release_bot=release_bot,
+                                                             conf=configuration),
+                     methods=['POST', ])
+
+    test_client = app.test_client()
+    return test_client
+
+
+def test_bad_requests(flask_instance):
+    """Test GET method request on different routes"""
+    response = flask_instance.get('/')
+    assert response.status_code == 404
+    response = flask_instance.get('/webhook-handler/')
+    assert response.status_code == 405
+
+
+def test_json_requests(flask_instance):
+    """Test if POST method which contains JSON call correct methods"""
+    flexmock(GithubWebhooksHandler).should_receive("handle_issue").once()
+    flexmock(GithubWebhooksHandler).should_receive("handle_pr").once()
+
+    json_dummy_dict = {
+      'dummy': 'dummy',
+    }
+    # will not call handle_issue or handle_pr within GithubWebhooksHandler instance
+    response = flask_instance.post('/webhook-handler/', data=json.dumps(json_dummy_dict),
+                                   content_type='application/json')
+    assert response.status_code == 200
+
+    json_expected_dict = {
+        'action': 'opened',
+        'issue': {
+            'dummy': 'dummy'
+        }
+    }
+    # call handle_issue once within GithubWebhooksHandler instance
+    response = flask_instance.post('/webhook-handler/', data=json.dumps(json_expected_dict),
+                                   content_type='application/json')
+    assert response.status_code == 200
+
+    json_expected_dict = {
+        'action': 'closed',
+        'pull_request': {
+            'merged': True,
+            'dummy': 'dummy'
+        }
+    }
+    # call handle_pr once within GithubWebhooksHandler instance
+    response = flask_instance.post('/webhook-handler/', data=json.dumps(json_expected_dict),
+                                   content_type='application/json')
+    assert response.status_code == 200
+


### PR DESCRIPTION
Implementation of Github callbacks related to  #112. 

As a quite new contributor I was thinking about more solutions for this feature, just tell me if there are possible improvements. This also could be integrated with #119 as github callbacks contains information about repository.  

Possible user workflow for this feature:
1. Deploy release-bot on Openshift online with openshift-template.yml
2. Set webhook to user's repo watched by release-bot.  
3. Add `webhook_hanlder: true` into `conf.yaml`

These steps should be added to README.md more specifically.