### PR TITLE
In openshift-template-dev add container repository into variable.

### DIFF
--- a/openshift-template-dev.yml
+++ b/openshift-template-dev.yml
@@ -137,6 +137,6 @@ parameters :
     value :
     required : true
   - name : DOCKER_IMAGE
-    description : DockerHub repository with release-bot container dev code
-    value :
+    description : DockerHub repository with release-bot development image
+    value : usercont/release-bot:dev
     required : true

--- a/openshift-template-dev.yml
+++ b/openshift-template-dev.yml
@@ -27,7 +27,7 @@ objects:
         - name : latest
           from :
             kind : DockerImage
-            name : usercont/release-bot:dev
+            name : ${DOCKER_IMAGE}
           importPolicy:
             scheduled: true
   - kind : BuildConfig
@@ -134,5 +134,9 @@ parameters :
     required : true
   - name : CONFIGURATION_REPOSITORY
     description : Git repository with configuration
+    value :
+    required : true
+  - name : DOCKER_IMAGE
+    description : DockerHub repository with release-bot container dev code
     value :
     required : true


### PR DESCRIPTION
It will be more straightforward if there is DockerHub repository in a variable within
openshift-template-dev.yml. I was stuck on this when I was working with my own container for the first time. "Production" template should stay without change. 

If you like this little change please marge it. 