### PR TITLE
Fixed empty warnings when the bot is unable to parse out the version.

### DIFF
--- a/release_bot/utils.py
+++ b/release_bot/utils.py
@@ -53,7 +53,7 @@ def process_version_from_title(title, latest_version):
     """
     match = False
     version = ''
-    re_match = re.match(r'(.+) release', title)
+    re_match = re.match(r'(.+) release$', title)
     if re_match:
         keyword = re_match[1].strip()
         if validate(keyword):

--- a/release_bot/utils.py
+++ b/release_bot/utils.py
@@ -69,7 +69,7 @@ def process_version_from_title(title, latest_version):
             match = True
             version = str(latest_version.next_patch())
         else:
-            logger.info(f"{title!r} is not a valid version")
+            logger.info(f"No valid version in {title!r}")
     return match, version
 
 

--- a/release_bot/utils.py
+++ b/release_bot/utils.py
@@ -69,7 +69,7 @@ def process_version_from_title(title, latest_version):
             match = True
             version = str(latest_version.next_patch())
         else:
-            logger.warning(f"{version!r} is not a valid version")
+            logger.info(f"{title!r} is not a valid version")
     return match, version
 
 


### PR DESCRIPTION
Solves #212 .

I also edited the regex so that it only matches when the word "release" is at the end of the issue title. For example: 

1. `new major release` will be matched
2. `0.1.1 release` will be matched
3. `let's release a version` will **NOT** be matched. (in the previous case, this would have been matched as well)