### PR TITLE
Make getting pypi project from setup.cfg work

### DIFF
--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -541,24 +541,24 @@ class Github:
         self.logger.error(f'Failed to put labels on issue #{number}')
         return False
 
-    def get_configuration(self):
+    def get_file(self, name):
         """
-        Fetches release-conf.yaml via Github API
-        :return: release-conf.yaml contents or False in case of error
+        Fetches a specific file via Github API
+        :return: file content or None in case of error
         """
         url = (f"{self.API3_ENDPOINT}repos/{self.conf.repository_owner}/"
-               f"{self.conf.repository_name}/contents/release-conf.yaml")
-        self.logger.debug(f'Fetching release-conf.yaml')
+               f"{self.conf.repository_name}/contents/{name}")
+        self.logger.debug(f'Fetching {name}')
         response = self.do_request(url=url, method='GET')
         if response.status_code != 200:
-            self.logger.error(f'Failed to fetch release-conf.yaml')
-            return False
+            self.logger.error(f'Failed to fetch {name}')
+            return None
 
         parsed = response.json()
         download_url = parsed['download_url']
         response = requests.get(url=download_url)
         if response.status_code != 200:
-            self.logger.error(f'Failed to fetch release-conf.yaml')
-            return False
+            self.logger.error(f'Failed to fetch {name}')
+            return None
 
         return response.text

--- a/release_bot/pypi.py
+++ b/release_bot/pypi.py
@@ -35,7 +35,6 @@ class PyPi:
         self.logger = configuration.logger
         self.git = git
 
-
     def latest_version(self):
         """Get latest version of the package from PyPi or 0.0.0"""
         response = requests.get(url=f"{self.PYPI_URL}{self.conf.pypi_project}/json")

--- a/release_bot/utils.py
+++ b/release_bot/utils.py
@@ -13,18 +13,17 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import shlex
 import datetime
+import locale
 import logging
 import os
 import re
+import shlex
 import subprocess
-import locale
-import configparser
+
 from semantic_version import validate
 
 from release_bot.exceptions import ReleaseException
-
 
 logger = logging.getLogger('release-bot')
 
@@ -258,24 +257,3 @@ def update_version(file, new_version, prefix):
             output.write('\n'.join(content) + '\n')
         logger.info('Version replaced.')
     return changed
-
-
-def get_pypi_project_from_setup_cfg(path=None):
-    """
-    Get the name of PyPI project from the metadata section of setup.cfg
-    :param path: str, path to setup.cfg
-    :return str or None, PyPI project name
-    """
-    path = path or "setup.cfg"
-
-    pypi_config = configparser.ConfigParser()
-    pypi_config.read(path)
-
-    if pypi_config:
-        try:
-            metadata = pypi_config["metadata"]
-            return metadata.get("name", None)
-        except KeyError:
-            return None
-
-    return None

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -76,9 +76,9 @@ class TestGithub:
 
         return number, response['data']['repository']['issue']['id']
 
-    def test_get_configuration(self):
+    def test_get_file(self):
         """Tests fetching release-conf from Github"""
-        assert self.github.get_configuration() == RELEASE_CONF
+        assert self.github.get_file("release-conf.yaml") == RELEASE_CONF
 
     def test_close_issue(self, open_issue):
         """Tests closing issue"""

--- a/tests/test_load_release_conf.py
+++ b/tests/test_load_release_conf.py
@@ -142,7 +142,13 @@ class TestLoadReleaseConf:
         assert valid_new_release['author_email'] == 'jsmith@example.com'
         assert valid_new_release['labels'] == ['bot', 'release-bot', 'user-cont']
 
-    def test_different_pypi_name(self, different_pypi_name_conf):
-        c = Configuration()
-        c.load_release_conf(different_pypi_name_conf)
-        assert c.pypi_project == "release-botos"
+    def test_set_pypi_name_from_release_conf(self, different_pypi_name_conf):
+        parsed_conf = configuration.load_release_conf(different_pypi_name_conf)
+        configuration.set_pypi_project(parsed_conf)
+        assert configuration.pypi_project == "release-botos"
+
+    def test_set_pypi_name_from_setup_cfg(self, valid_conf):
+        parsed_conf = configuration.load_release_conf(valid_conf)
+        setup_cfg = Path(__file__).parent.joinpath("src/test-setup.cfg").read_text()
+        configuration.set_pypi_project(parsed_conf, setup_cfg)
+        assert configuration.pypi_project == "release-botos"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,13 +13,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests utility functions"""
-from os import chdir
 from pathlib import Path
 
 from semantic_version import Version
+
 from release_bot.utils import (process_version_from_title,
                                look_for_version_files)
-from release_bot.utils import get_pypi_project_from_setup_cfg
 
 
 def test_process_version_from_title():
@@ -65,8 +64,3 @@ def test_look_for_version_files(tmpdir):
 
     assert set(look_for_version_files(str(dir1), "1.2.5")) == \
         {"setup.py", "__init__.py"}
-
-
-def test_get_pypi_project_name():
-    assert get_pypi_project_from_setup_cfg(
-        Path(__file__).parent / "src/test-setup.cfg") == "release-botos"


### PR DESCRIPTION
Previously `get_pypi_project_from_setup_cfg()` aways returned `None`
because we had not fetched the `setup.cfg` before calling it.