### PR TITLE
Handling exceptions in init phase.

### DIFF
--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -419,7 +419,7 @@ class Github:
         """
         Makes the steps to prepare new branch for the release PR,
         like generating changelog and updating version
-        :param new_pr: dict with info about the new release
+        :param new_pr: object of class new_pr with info about the new release
         :param gitchangelog: bool, use gitchangelog
         :return: True on success, False on fail
         """

--- a/release_bot/init_repo.py
+++ b/release_bot/init_repo.py
@@ -101,10 +101,12 @@ from shell run 'release-bot -c conf.yaml'"""
             print("""For details on how to get github token checkout
     'https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/'""")
             self.conf['github_token'] = input('Please enter your valid github token:')
-            refresh_interval = input("""In how many seconds would you like the
+            refresh_interval = "dummy"
+            while not (refresh_interval.isdigit() or refresh_interval == ""):
+                refresh_interval = input("""In how many seconds would you like the
     bot to check for updates (Default 180):""")
             if refresh_interval:
-                self.conf['refresh_interval'] = int(refresh_interval)
+                self.conf['refresh_interval'] = refresh_interval
             else:
                 self.conf['refresh_interval'] = 180
             is_owner_user = input('Are you the owner of the repo? (Y/n):')

--- a/release_bot/init_repo.py
+++ b/release_bot/init_repo.py
@@ -17,6 +17,7 @@
 This module initializes a repo to be used by ReleaseBot
 """
 import os
+import re
 import yaml
 
 from release_bot.utils import run_command_get_output
@@ -94,7 +95,14 @@ from shell run 'release-bot -c conf.yaml'"""
         cwd = os.getcwd()
         self.release_conf['author_email'] = run_command_get_output(cwd, f'git config user.email')[1].strip()
         self.release_conf['author_name'] = run_command_get_output(cwd, f'git config user.name')[1].strip()
-
+        if self.release_conf['author_email'] == "":
+            print("WARNING: your e-mail ID from git config is not set."+
+                  "\nPlease set it using 'git config user.email \"email@example.com\"'")
+        elif not re.match(r"[^@]+@[^@]+\.[^@]+", self.release_conf["author_email"]):
+            print("WARNING: your e-mail ID from git config is not a valid e-mail address.")
+        if self.release_conf['author_name'] == "":
+            print("WARNING: your username from git config is not set." +
+                  "\nPlease set it using 'git config user.name \"John Doe\"'")
         if not silent:
             self.conf['repository_name'] = input('Please enter the repository name:')
             self.conf['repository_owner'] = input('Please enter the repository owner:')

--- a/release_bot/init_repo.py
+++ b/release_bot/init_repo.py
@@ -123,7 +123,7 @@ from shell run 'release-bot -c conf.yaml'"""
                 refresh_interval = input("""In how many seconds would you like the
     bot to check for updates (Default 180):""")
             if refresh_interval:
-                self.conf['refresh_interval'] = refresh_interval
+                self.conf['refresh_interval'] = int(refresh_interval)
             else:
                 self.conf['refresh_interval'] = 180
             is_owner_user = input('Are you the owner of the repo? (Y/n):')

--- a/release_bot/init_repo.py
+++ b/release_bot/init_repo.py
@@ -67,6 +67,15 @@ class Init:
             'labels': []
         }
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        if exc_type is KeyboardInterrupt:
+            print("\nOperation aborted by user.")
+            return True
+        return exc_type is None
+
     def run(self, silent):
         """
         Performs all the init tasks

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -313,7 +313,8 @@ def main():
     args = CLI.parse_arguments()
     if args.subcommand == "run_init":
         init_repo = Init()
-        init_repo.run(args.silent)
+        with Init() as init_repo:
+            init_repo.run(args.silent)
     else:
         CLI.get_configuration(args)
         configuration.load_configuration()


### PR DESCRIPTION
As discussed [here](https://github.com/user-cont/release-bot/pull/226#issuecomment-496225678).

There's one commit which fixes a docstring in github.py as well.

So far, this PR includes:
1. Handling an exception when an incorrect value is given to the refresh_interval parameter. 
2. Shows warnings for incorrectly set git credentials (email and username). 
3. Prints a message when the operation is interrupted by the user, instead of printing the whole stacktrace.

I was unsure on how to format the messages. It can be discussed upon, if required.