### PR TITLE
commenting on Issues/PRs with ogr

### DIFF
--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -20,9 +20,9 @@ import sys
 from pathlib import Path
 
 import yaml
-from ogr.services.github import GithubService
-from ogr.services.pagure import PagureService
-from ogr.factory import get_project
+from ogr import GithubService
+from ogr import PagureService
+from ogr import get_project
 
 from release_bot.version import __version__
 

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -20,9 +20,7 @@ import sys
 from pathlib import Path
 
 import yaml
-from ogr import GithubService
-from ogr import PagureService
-from ogr import get_project
+from ogr import GithubService, PagureService, get_project
 
 from release_bot.version import __version__
 

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -168,27 +168,6 @@ class Github:
                       f'name: "{self.conf.repository_name}") {{{query}}}}}')
         return self.do_request(query=repo_query)
 
-    def add_comment(self, subject_id):
-        """Add self.comment to subject_id issue/PR"""
-        if not subject_id or not self.comment:
-            return
-        if self.conf.dry_run:
-            self.logger.info("I would add a comment to the pull request created.")
-            return None
-        comment = '\n'.join(self.comment)
-        mutation = (f'mutation {{addComment(input:'
-                    f'{{subjectId: "{subject_id}", body: "{comment}"}})' +
-                    '''{
-                         subject {
-                           id
-                         }
-                       }}''')
-        response = self.do_request(query=mutation, use_github_auth=True).json()
-        self.detect_api_errors(response)
-        self.logger.debug(f'Comment added to PR: {comment}')
-        self.comment = []  # clean up
-        return response
-
     @staticmethod
     def detect_api_errors(response):
         """This function looks for errors in API response"""

--- a/release_bot/new_release.py
+++ b/release_bot/new_release.py
@@ -24,6 +24,7 @@ class NewRelease:
         self.trigger_on_issue = None
         self.labels = None
         self.pr_id = None
+        self.pr_number = None
         self.commitish = None
         self.version = None
 
@@ -36,10 +37,11 @@ class NewRelease:
         self.trigger_on_issue = trigger_on_issue
         self.labels = labels
 
-    def update_pr_details(self, version, author_name, author_email, pr_id, commitish):
+    def update_pr_details(self, version, author_name, author_email, pr_id, pr_number, commitish):
         # Update attributes for making a PR
         self.author_name = author_name
         self.author_email = author_email
         self.pr_id = pr_id
+        self.pr_number = pr_number
         self.version = version
         self.commitish = commitish

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -93,10 +93,11 @@ class ReleaseBot:
 
         :return: str
         """
-        if type(self.project.service) == GithubService:
+        if isinstance(self.project.service, GithubService):
             return "Github"
-        elif type(self.project.service) == PagureService:
+        elif isinstance(self.project.service, PagureService):
             return "Pagure"
+        return None
 
     def find_open_release_issues(self):
         """

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -304,7 +304,7 @@ class ReleaseBot:
                 except ReleaseException as exc:
                     self.logger.error(exc)
 
-                msg = ''.join(self.github.comment)
+                msg = '\n'.join(self.github.comment)
                 self.project.pr_comment(self.new_release.pr_number, msg)
                 self.github.comment = []  # clean up
 

--- a/release_bot/webhooks.py
+++ b/release_bot/webhooks.py
@@ -88,4 +88,7 @@ class GithubWebhooksHandler(View):
                 self.release_bot.make_new_pypi_release()
         except ReleaseException as exc:
             self.logger.error(exc)
-        self.release_bot.github.add_comment(self.release_bot.new_release.get('pr_id'))
+
+        msg = ''.join(self.release_bot.github.comment)
+        self.release_bot.project.pr_comment(self.release_bot.new_release.pr_number, msg)
+        self.release_bot.github.comment = []  # clean up

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyJWT
 flask
 gitchangelog
 pystache
+ogr@git+https://github.com/packit-service/ogr@master#egg=ogr

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ PyJWT
 flask
 gitchangelog
 pystache
-ogr

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyJWT
 flask
 gitchangelog
 pystache
+ogr

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -48,6 +48,7 @@ class TestBot:
         configuration.github_username = self.github_user
         configuration.clone_url = f'https://github.com/{self.github_user}/{self.g_utils.repo}.git'
         configuration.refresh_interval = 1
+        configuration.project = configuration.get_project()
 
         self.release_bot = ReleaseBot(configuration)
 
@@ -123,6 +124,10 @@ class TestBot:
             conf['pypi'] = True
         for key, value in conf.items():
             assert getattr(self.release_bot.new_release, key) == value
+
+    def test_git_service(self):
+        git_service = self.release_bot.git_service
+        assert git_service == "Github"
 
     def test_find_open_rls_issue(self, open_issue):
         """Tests if bot can find opened release issue"""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -96,13 +96,3 @@ class TestGithub:
         """Tests if branch doesn't exist"""
         assert not self.github.branch_exists('not-master')
 
-    def test_add_comment(self, open_issue_graphql):
-        """Tests adding comment on issue"""
-        number, graphql_id = open_issue_graphql
-        comments_count = self.g_utils.count_comments(number)
-        self.github.comment = "Test comment"
-        self.github.conf.dry_run = True
-        assert self.github.add_comment(graphql_id) is None
-        self.github.conf.dry_run = False
-        self.github.add_comment(graphql_id)
-        assert self.g_utils.count_comments(number) == comments_count + 1


### PR DESCRIPTION
Commenting on Issues and PRs are available for Github but also Pagure since now. I added two new variables into the private config file `pagure_token` and `pagure_username`. I'm just thinking if we should add this into README or wait till all Github features will be implemented also for Pagure.

Ogr doesn't have released commenting on issues yet. If you want to try locally you must install ogr from Github, not from requirements.txt
`pip install git+https://github.com/packit-service/ogr@master` 