### PR TITLE
closing issues using ogr

### DIFF
--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -27,7 +27,7 @@ from release_bot.version import __version__
 
 class Configuration:
     # note that required items need to reference strings as their length is checked
-    REQUIRED_ITEMS = {"conf": ['repository_name', 'repository_owner', 'clone_url'],
+    REQUIRED_ITEMS = {"conf": ['repository_name', 'repository_owner'],
                       "release-conf": []}
 
     def __init__(self):

--- a/release_bot/configuration.py
+++ b/release_bot/configuration.py
@@ -27,7 +27,7 @@ from release_bot.version import __version__
 
 class Configuration:
     # note that required items need to reference strings as their length is checked
-    REQUIRED_ITEMS = {"conf": ['repository_name', 'repository_owner', 'github_token'],
+    REQUIRED_ITEMS = {"conf": ['repository_name', 'repository_owner', 'clone_url'],
                       "release-conf": []}
 
     def __init__(self):
@@ -53,7 +53,7 @@ class Configuration:
         self.github_app_cert_path = ''
         self.clone_url = ''
         # used for different pagure forges pagure.io by default
-        self.pagure_instance_url = 'pagure.io'
+        self.pagure_instance_url = 'https://pagure.io'
         self.webhook_handler = False
         self.gitchangelog = False
         self.project = None
@@ -143,10 +143,13 @@ class Configuration:
                 sys.exit(1)
         for index, label in enumerate(parsed_conf.get('labels', [])):
             parsed_conf['labels'][index] = str(label)
-        if parsed_conf.get('trigger_on_issue') and not self.github_username:
-            msg = "Can't trigger on issue if 'github_username' is not known, disabling"
-            self.logger.warning(msg)
-            parsed_conf['trigger_on_issue'] = False
+
+        if parsed_conf.get('trigger_on_issue'):
+            if not self.github_username and not self.pagure_username:
+                msg = ("Can't trigger on issue if "
+                       "'github_username/pagure_username' is not known, disabling")
+                self.logger.warning(msg)
+                parsed_conf['trigger_on_issue'] = False
 
         return parsed_conf
 

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -100,6 +100,7 @@ class Github:
         """
         self.conf = configuration
         self.logger = configuration.logger
+        self.project = configuration.project
         self.session = requests.Session()
         self.session.headers.update({'Authorization': f'token {configuration.github_token}'})
         self.github_app_session = None
@@ -511,25 +512,17 @@ class Github:
         self.logger.error(f'Failed to put labels on issue #{number}')
         return False
 
-    def get_file(self, name, service):
+    def get_file(self, name):
         """
         Fetches a specific file via Github API
         @:param: str, name of the file
-        @:param: str, Github/Pagure
         :return: file content or None in case of error
         """
-        file_url = ""
-        if service == 'Github':
-            file_url = (f"https://raw.githubusercontent.com/"
-                        f"{self.conf.repository_owner}/{self.conf.repository_name}/master/{name}")
-        if service == 'Pagure':
-            file_url = (f"https://pagure.io/"
-                        f"{self.conf.repository_name}/raw/master/f/{name}")
-
-        self.logger.debug(f'Fetching {file_url}')
-        response = requests.get(url=file_url)
-        if response.status_code != 200:
-            self.logger.error(f'Failed to fetch {file_url}')
+        self.logger.debug(f'Fetching {name}')
+        try:
+            file = self.project.get_file_content(path=name)
+        except FileNotFoundError:
+            self.logger.error(f'Failed to fetch {name}')
             return None
 
-        return response.text
+        return file

--- a/release_bot/github.py
+++ b/release_bot/github.py
@@ -252,30 +252,6 @@ class Github:
             self.detect_api_errors(response)
             return response['data']['repository']['pullRequests']['edges']
 
-    def walk_through_open_issues(self, start='', direction='after', which="last"):
-        """
-        Searches open issues for a release trigger
-
-        :return: edges from API query response
-        """
-        while True:
-            query = (f"issues(states: OPEN {which}: 5 " +
-                     (f'{direction}: "{start}"' if start else '') +
-                     '''){
-                  edges {
-                    cursor
-                    node {
-                      id
-                      number
-                      title
-                      authorAssociation
-                    }
-                  }
-                }''')
-            response = self.query_repository(query).json()
-            self.detect_api_errors(response)
-            return response['data']['repository']['issues']['edges']
-
     def make_new_release(self, new_release):
         """
         Makes new release to Github.

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -74,9 +74,9 @@ class ReleaseBot:
         :return:
         """
         # load release configuration from release-conf.yaml in repository
-        conf = self.github.get_file("release-conf.yaml", self.which_service())
+        conf = self.github.get_file("release-conf.yaml")
         release_conf = self.conf.load_release_conf(conf)
-        setup_cfg = self.github.get_file("setup.cfg", self.which_service())
+        setup_cfg = self.github.get_file("setup.cfg")
         self.conf.set_pypi_project(release_conf, setup_cfg)
 
         self.new_release.update(
@@ -108,7 +108,7 @@ class ReleaseBot:
         release_issues = {}
         latest_version = Version(self.github.latest_release())
         opened_issues = self.project.get_issue_list(IssueStatus.open)
-        if len(opened_issues) == 0:
+        if not opened_issues:
             self.logger.debug(f'No more open issues found')
         else:
             for issue in opened_issues:

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -114,9 +114,8 @@ class ReleaseBot:
             for issue in opened_issues:
                 match, version = process_version_from_title(issue.title, latest_version)
                 if match:
-                    allowed_users = self.project.who_can_close_issue()
-                    if (self.conf.github_username in allowed_users
-                            or self.conf.pagure_username in allowed_users):
+                    if (self.project.can_close_issue(self.conf.github_username, issue)
+                            or self.project.can_close_issue(self.conf.pagure_username, issue)):
                         release_issues[version] = issue
                         self.logger.info(f'Found new release issue with version: {version}')
                     else:
@@ -135,7 +134,8 @@ class ReleaseBot:
             if self.which_service() == "Github":
                 labels = self.new_release.labels
             else:
-                labels = None  # Pagure can't put labels on issue
+                # Putting labels on Pagure issues is not implemented yet inside ogr-lib
+                labels = None
 
             for version, issue in release_issues.items():
                 self.new_pr.update_new_pr_details(

--- a/release_bot/releasebot.py
+++ b/release_bot/releasebot.py
@@ -100,6 +100,18 @@ class ReleaseBot:
             return "Pagure"
         return None
 
+    def which_username(self):
+        """
+        Returns Github/Pagure username based on current project service
+
+        :return: str
+        """
+        if self.which_service() == "Github":
+            return self.conf.github_username
+        elif self.which_service() == "Pagure":
+            return self.conf.pagure_username
+        return None
+
     def find_open_release_issues(self):
         """
         Looks for opened release issues on github
@@ -114,17 +126,12 @@ class ReleaseBot:
             for issue in opened_issues:
                 match, version = process_version_from_title(issue.title, latest_version)
                 if match:
-                    if (self.project.can_close_issue(self.conf.github_username, issue)
-                            or self.project.can_close_issue(self.conf.pagure_username, issue)):
+                    if self.project.can_close_issue(self.which_username(), issue):
                         release_issues[version] = issue
                         self.logger.info(f'Found new release issue with version: {version}')
                     else:
-                        if self.which_service() == "Github":
-                            self.logger.warning(f"User {self.conf.github_username } "
-                                                f"has no permission to modify issue")
-                        else:
-                            self.logger.warning(f"User {self.conf.pagure_username} "
-                                                f"has no permission to modify issue")
+                        self.logger.warning(f"User {self.which_username()} "
+                                            f"has no permission to modify issue")
 
         if len(release_issues) > 1:
             msg = f'Multiple release issues are open {release_issues}, please reduce them to one'

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -129,6 +129,15 @@ class TestBot:
         git_service = self.release_bot.git_service
         assert git_service == "Github"
 
+    def test_which_service(self):
+        git_service = self.release_bot.which_service()
+        assert git_service == "Github"
+
+    def test_which_username(self):
+        git_username = self.release_bot.which_username()
+        assert git_username == self.github_user
+        assert git_username == self.release_bot.conf.github_username
+
     def test_find_open_rls_issue(self, open_issue):
         """Tests if bot can find opened release issue"""
         assert self.release_bot.find_open_release_issues()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -78,7 +78,7 @@ class TestGithub:
 
     def test_get_file(self):
         """Tests fetching release-conf from Github"""
-        assert self.github.get_file("release-conf.yaml", "Github") == RELEASE_CONF
+        assert self.github.get_file("release-conf.yaml") == RELEASE_CONF
 
     def test_latest_rls_not_existing(self):
         """Tests version number when there is no latest release"""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -43,7 +43,9 @@ class TestGithub:
         # set conf
         configuration.repository_name = self.g_utils.repo
         configuration.github_username = self.g_utils.github_user
+        configuration.clone_url = f"https://github.com/{self.g_utils.github_user}/{self.g_utils.repo}.git"
         configuration.refresh_interval = 1
+        configuration.project = configuration.get_project()
 
         repo_url = f"https://github.com/{self.g_utils.github_user}/{self.g_utils.repo}"
         git = Git(repo_url, configuration)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -78,11 +78,7 @@ class TestGithub:
 
     def test_get_file(self):
         """Tests fetching release-conf from Github"""
-        assert self.github.get_file("release-conf.yaml") == RELEASE_CONF
-
-    def test_close_issue(self, open_issue):
-        """Tests closing issue"""
-        assert self.github.close_issue(open_issue)
+        assert self.github.get_file("release-conf.yaml", "Github") == RELEASE_CONF
 
     def test_latest_rls_not_existing(self):
         """Tests version number when there is no latest release"""


### PR DESCRIPTION
Related to #190, #193, but still not fully implement these issues.

I replaced Github API with ogr for closing and checking Issues.
Integration tests are passing for Github, unit tests are provided in ogr. I still need to add several features into ogr to fully support Pagure, then I can write tests for Pagure too. 