### PR TITLE
Temporary lock ogr to 0.8.0 to make tests pass

### DIFF
--- a/files/install-rpm-packages.yaml
+++ b/files/install-rpm-packages.yaml
@@ -8,7 +8,7 @@
       - python3-flask
       - python3-ipdb  # for easy debugging
       - python3-jsonschema
-      - python3-ogr
+      #- python3-ogr  # temporary install 0.8.0 from PyPI
       - python3-pip
       - python3-pyyaml
       - python3-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ gitchangelog
 pystache
 celery[redis]
 cryptography
-ogr
+ogr==0.8.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,7 +51,7 @@ install_requires =
     celery
     redis
     cryptography
-    ogr>=0.7.0
+    ogr
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
and avoid DeprecationWarnings (in 0.9.0)