### PR TITLE
Setup requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+requests==2.22.0
+Flask==1.0.3
+celery==4.4.0
+flexmock==0.10.4
+ogr==0.8.0
+PyJWT==1.7.1
+pytest==5.3.5
+PyYAML==5.3
+redis==3.4.1
+semantic_version==2.8.4


### PR DESCRIPTION
Add a `requirements.txt` to support installation of dependencies from `pip` using 
```
pip install -r requirements.txt
```
Helps gaining more control over the version of packages installed and is an easier method of installation while testing locally.